### PR TITLE
chore: add changesets for fable_fixes

### DIFF
--- a/.changeset/fable-analytics.md
+++ b/.changeset/fable-analytics.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/analytics": patch
+---
+
+Add an optional `options` argument to `VendorReporter` (with `VendorReporterOptions`, background-error handling, and a default timeout).

--- a/.changeset/fable-authentication.md
+++ b/.changeset/fable-authentication.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/authentication": patch
+---
+
+Add typed error classes (invalid scrypt cost, password hash, invalid TOTP secret, invalid token length) and validate inputs more strictly.

--- a/.changeset/fable-cache.md
+++ b/.changeset/fable-cache.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/cache": minor
+---
+
+Add a required `close()` method to the `Cache` and `BatchCache` interfaces. Breaking for external `Cache` implementers. New config: `maxEntries`, `commandTimeoutMs`, `connectTimeoutMs`.

--- a/.changeset/fable-circuitbreaking.md
+++ b/.changeset/fable-circuitbreaking.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/circuitbreaking": patch
+---
+
+Add metrics instrumentation and half-open stall recovery.

--- a/.changeset/fable-compression.md
+++ b/.changeset/fable-compression.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/compression": minor
+---
+
+Add required `compressStream()` and `decompressStream()` methods to the `Compressor` interface. Breaking for external `Compressor` implementers. Adds a typed `CompressionError`.

--- a/.changeset/fable-cookies.md
+++ b/.changeset/fable-cookies.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/cookies": patch
+---
+
+Add `httpOnly` config, `MAX_COOKIE_BYTES`/`cookieByteLength` exports, and stricter cookie serialization validation.

--- a/.changeset/fable-cryptography.md
+++ b/.changeset/fable-cryptography.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/cryptography": minor
+---
+
+Add a required `readonly authenticated: boolean` member to the `Encryptor` interface. Breaking for external `Encryptor` implementers. AES-GCM now validates key length at construction.

--- a/.changeset/fable-database.md
+++ b/.changeset/fable-database.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/database": minor
+---
+
+Add a required `ensureReady()` method to `DatabaseClient` and change `mysqlDsn()` output to a `mysql://` URL. Breaking for custom `DatabaseClient` implementers and consumers of the previous DSN format. Adds pool-settings helpers.

--- a/.changeset/fable-distributedlock.md
+++ b/.changeset/fable-distributedlock.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/distributedlock": minor
+---
+
+Change `Lock.release()` and `Lock.refresh()` to return `Promise<boolean>` (was `Promise<void>`) and add a required `close()` to `DistributedLock`. Breaking for callers and implementers. Adds command/connect timeouts.

--- a/.changeset/fable-email.md
+++ b/.changeset/fable-email.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/email": patch
+---
+
+Add per-provider `timeoutMs` and optional `retry` config, a shared HTTP sender, and sender instrumentation.

--- a/.changeset/fable-encoding.md
+++ b/.changeset/fable-encoding.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/encoding": patch
+---
+
+Add request body size limits and content-type allow-listing, with `RequestBodyTooLargeError` and `UnsupportedContentTypeError`.

--- a/.changeset/fable-errors.md
+++ b/.changeset/fable-errors.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/errors": patch
+---
+
+Improve `messageOf()` handling of plain objects and let `wrap()` preserve `PlatformError` subclasses.

--- a/.changeset/fable-eventstream.md
+++ b/.changeset/fable-eventstream.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/eventstream": minor
+---
+
+Widen the injectable `EventSourceLike` interface with required `readyState` and `removeEventListener` members. Breaking for custom `EventSourceLike` implementations (standard EventSource implementations are unaffected). Adds heartbeat and reconnect options.

--- a/.changeset/fable-featureflags.md
+++ b/.changeset/fable-featureflags.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/featureflags": minor
+---
+
+Add a required `close()` method to the `FeatureFlagManager` interface. Breaking for direct implementers (`BaseFeatureFlagManager` supplies a default).

--- a/.changeset/fable-files.md
+++ b/.changeset/fable-files.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/files": patch
+---
+
+Throw `PathEscapesBaseError` when a resolved path escapes its base directory.

--- a/.changeset/fable-healthcheck.md
+++ b/.changeset/fable-healthcheck.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/healthcheck": patch
+---
+
+Add a per-check timeout via `HealthRegistryOptions` and propagate aborts instead of reporting unhealthy.

--- a/.changeset/fable-httpclient.md
+++ b/.changeset/fable-httpclient.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/httpclient": patch
+---
+
+Add an optional `idempotent` request option and improve tracing, metrics, and query redaction in the fetch provider.

--- a/.changeset/fable-identifiers.md
+++ b/.changeset/fable-identifiers.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/identifiers": patch
+---
+
+Tighten ULID validation to reject timestamp-overflow values.

--- a/.changeset/fable-llm.md
+++ b/.changeset/fable-llm.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/llm": minor
+---
+
+Add a required `completeStream()` method to the `LLMProvider` interface. Breaking for external `LLMProvider` implementers. Adds `timeoutMs`/`retry` config and request cancellation via `signal`.

--- a/.changeset/fable-messagequeue.md
+++ b/.changeset/fable-messagequeue.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/messagequeue": minor
+---
+
+Make `Publisher.stop()` and `PublisherProvider.close()` async (now return `Promise<void>`) and add a required `close()` to `ConsumerProvider`. Breaking for callers and implementers.

--- a/.changeset/fable-notifications.md
+++ b/.changeset/fable-notifications.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/notifications": minor
+---
+
+Remove the `ErrPlatformNotSupported` export (replaced by `newPlatformNotSupportedError()` and `PLATFORM_NOT_SUPPORTED_MESSAGE`) and add a required `close()` to `PushNotificationSender`. Breaking for importers and implementers. The `secure` config default is now `true`.

--- a/.changeset/fable-numbers.md
+++ b/.changeset/fable-numbers.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/numbers": patch
+---
+
+Fix `round()` returning `NaN` for very large magnitudes.

--- a/.changeset/fable-observability.md
+++ b/.changeset/fable-observability.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/observability": minor
+---
+
+Remove the `name` field from the metrics and tracing config schemas and default both providers to OpenTelemetry (`otel`). Breaking for configs that set `name` or relied on the previous `noop` default. Logger/Operation gained additive optional members.

--- a/.changeset/fable-qrcodes.md
+++ b/.changeset/fable-qrcodes.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/qrcodes": patch
+---
+
+Wrap thrown errors in a typed `QRCodeError`.

--- a/.changeset/fable-random.md
+++ b/.changeset/fable-random.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/random": patch
+---
+
+Fix base64url encoding of large byte arrays via chunked encoding.

--- a/.changeset/fable-ratelimiting.md
+++ b/.changeset/fable-ratelimiting.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/ratelimiting": minor
+---
+
+Add a required `close()` method to the `RateLimiter` interface. Breaking for external implementers. Adds `failOpen`, connection timeouts, and `assertValidCost()`.

--- a/.changeset/fable-retry.md
+++ b/.changeset/fable-retry.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/retry": minor
+---
+
+Add a required `warn()` method to the `RetryLogger` interface. Breaking for injected loggers that lack `warn`. Adds `maxElapsedMs` config and `RunOptions`.

--- a/.changeset/fable-search.md
+++ b/.changeset/fable-search.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/search": patch
+---
+
+Add bulk indexing interfaces (`BulkIndexManager`, `BulkTextIndex`, `BulkDocument`), type guards, and a default search limit.

--- a/.changeset/fable-secrets.md
+++ b/.changeset/fable-secrets.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/secrets": patch
+---
+
+Add a caching secret source (`CachingSecretSource`) with TTL config and real `ping()` probes.

--- a/.changeset/fable-uploads.md
+++ b/.changeset/fable-uploads.md
@@ -1,0 +1,5 @@
+---
+"@primandproper/uploads": minor
+---
+
+Replace the `ErrCircuitBroken` sentinel export with `newCircuitBrokenError()` and `CIRCUIT_BROKEN_CODE`. Breaking for code importing or comparing against `ErrCircuitBroken`. Adds `maxSizeBytes` config and `newFileTooLargeError()`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,37 @@ jobs:
 
       - name: ${{ matrix.task }}
         run: pnpm run ${{ matrix.task }}
+
+  # Fail a PR that ships code without declaring a release intent. `changeset
+  # status` on 2.x exits 0 even with zero changesets, so we read its JSON and
+  # fail when nothing would be bumped. For a deliberately release-neutral PR
+  # (docs, CI, chore), add an empty changeset: `pnpm changeset --empty`.
+  changeset:
+    name: changeset
+    # Only PRs need a changeset; a push to main is the merge itself.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # `--since` needs history and the base branch
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Require a changeset
+        run: |
+          pnpm changeset status --since=origin/${{ github.base_ref }} --output=changeset-status.json
+          count=$(node -p "require('./changeset-status.json').releases.length")
+          if [ "$count" -eq 0 ]; then
+            echo "::error::No changeset found on this branch. Run 'pnpm changeset' to describe the release, or 'pnpm changeset --empty' for a release-neutral change."
+            exit 1
+          fi
+          echo "$count package(s) will be released. 🦋"


### PR DESCRIPTION

---

## Also in this PR: a CI gate to prevent recurrence

Adds a PR-only `changeset` job to `ci.yml` that **fails any PR which declares no release intent** — the exact gap that let `fable_fixes` merge silently. Because `changeset status` exits `0` on 2.x even with zero changesets, the job reads its JSON output and fails when `releases` is empty. Scoped to the base branch via `--since=origin/${{ github.base_ref }}`.

Release-neutral PRs (docs, CI, chore) opt out explicitly with `pnpm changeset --empty`. This PR passes its own gate — it carries 30 changesets.
