### PR TITLE
fix(ci): don't require a changeset on the release PR

### DIFF
--- a/.changeset/ci-skip-changeset-release-pr.md
+++ b/.changeset/ci-skip-changeset-release-pr.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI only: skip the "require a changeset" job on the Changesets release PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,17 @@ jobs:
 
   # Fail a PR that ships code without declaring a release intent. `changeset
   # status` on 2.x exits 0 even with zero changesets, so we read its JSON and
-  # fail when nothing would be bumped. For a deliberately release-neutral PR
-  # (docs, CI, chore), add an empty changeset: `pnpm changeset --empty`.
+  # fail when no changeset was declared. For a deliberately release-neutral PR
+  # (docs, CI, chore), add an empty changeset: `pnpm changeset --empty`. We key
+  # off `changesets.length` (was a changeset declared?) rather than
+  # `releases.length` (would anything be bumped?), because an empty changeset
+  # bumps nothing yet is still a valid, deliberate declaration.
   changeset:
     name: changeset
-    # Only PRs need a changeset; a push to main is the merge itself.
-    if: github.event_name == 'pull_request'
+    # Only PRs need a changeset; a push to main is the merge itself. The
+    # Changesets "Version Packages" PR (from changeset-release/main) is exempt:
+    # it *consumes* changesets, so requiring one there is a self-defeating loop.
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -64,9 +69,10 @@ jobs:
       - name: Require a changeset
         run: |
           pnpm changeset status --since=origin/${{ github.base_ref }} --output=changeset-status.json
-          count=$(node -p "require('./changeset-status.json').releases.length")
-          if [ "$count" -eq 0 ]; then
+          declared=$(node -p "require('./changeset-status.json').changesets.length")
+          if [ "$declared" -eq 0 ]; then
             echo "::error::No changeset found on this branch. Run 'pnpm changeset' to describe the release, or 'pnpm changeset --empty' for a release-neutral change."
             exit 1
           fi
-          echo "$count package(s) will be released. 🦋"
+          releases=$(node -p "require('./changeset-status.json').releases.length")
+          echo "$declared changeset(s) declared; $releases package(s) will be released. 🦋"


### PR DESCRIPTION
## Problem

The `changeset` CI job (`Require a changeset`) runs on **every** PR. The Changesets bot's "Version Packages" PR (from `changeset-release/main`, currently #4) *consumes* changesets — it deletes every `.changeset/*.md` and bumps versions instead. So on that PR the job sees changed packages with zero changesets and fails, in a self-defeating loop the release PR can never satisfy.

```
🦋  error Some packages have been changed but no changesets were found.
```

## Fix

1. **Skip the job on the release branch** — add `&& github.head_ref != 'changeset-release/main'` to the job's `if`. The release PR is exempt by design.

2. **Make the documented `--empty` escape hatch actually work** — the check keyed off `releases.length`, but an empty changeset yields `releases.length === 0`, so the workaround the comment already recommends (`pnpm changeset --empty`) would have failed too. Key off `changesets.length` (*was a changeset declared?*) instead.

## Guarantee: the "you forgot a changeset" warning is unchanged

`changeset status` **itself exits 1** when a package changes with no changeset (that's the error above), failing the step before the node logic runs. This edit only affects the empty-changeset case:

| Scenario | Original | This PR |
|---|---|---|
| package changed, **no changeset** | fails ✅ | fails ✅ |
| package changed, real changeset | passes | passes |
| package changed, only **empty** changeset | fails | passes |
| no package changed, empty changeset (CI/docs) | fails | passes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)