### PR TITLE
feat(database): transaction support

### DIFF
--- a/.changeset/database-transactions.md
+++ b/.changeset/database-transactions.md
@@ -1,0 +1,32 @@
+---
+"@primandproper/database": minor
+---
+
+Add `DatabaseClient.withTransaction(fn)`: several statements on one pinned write connection,
+committing when `fn` resolves and rolling back — then re-throwing the original error unchanged —
+when it rejects. This is the hard prerequisite for the `outbox` port, whose entire guarantee rests
+on the event insert being a statement in the caller's transaction.
+
+`fn` receives a bare `Queryable` (`query` and nothing else), so it cannot commit, roll back, close
+the pool, or outlive the closure — lifecycle stays with the method that owns it. `QueryablePool`
+now extends `Queryable`, so a helper written against the narrow type accepts a pool or a
+transaction, which is what lets `outbox.enqueue` make "holding a `Queryable`" _mean_ "inside a
+transaction". `DatabaseClient.query` widened to `Queryable` for the same reason, so statements
+inside a transaction are instrumented like any other.
+
+A transaction is a pinned connection rather than a pool, so `QueryablePool` gains an optional
+`connect()` and each adapter supplies it — `pool.connect()` for pg, `getConnection()` for mysql,
+and a write lock for sqlite, which has one connection and no nested transactions (a second `BEGIN`
+would silently join the first one's scope). A pool that cannot pin a connection throws
+`TransactionsUnsupportedError` instead of spreading the statements across arbitrary pooled
+connections, which is the failure that looks like it worked. The connection is released in a
+`finally` — including when `BEGIN`, the callback, the rollback, or the commit failed — since one
+leaked connection per transaction exhausts the pool and presents as unrelated latency.
+
+Documented and tested behaviour: a failed rollback is logged rather than replacing the error that
+caused it; a failed `COMMIT` raises `TransactionCommitError` (distinct in kind — the outcome is
+unknown, not provably absent) and attempts no second rollback; nesting on the same client throws
+`NestedTransactionError` rather than flattening two scopes, detected per async context so
+concurrent transactions on one client still work, and a different client's transaction may nest.
+Covered by a provider-agnostic conformance suite run through the postgres, mysql, and sqlite
+adapters.

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -11,6 +11,7 @@ deliberately a narrow slice — **no query-executor inheritance, no migrations**
 - **Config + DSN builders** (`postgres` / `mysql` / `sqlite`), matching platform-go's defaults.
 - An **instrumented client** (`DatabaseClient`) over a `QueryablePool` seam: spans on queries,
   ping-with-retry readiness, lifecycle, and an injectable clock.
+- **Transactions** (`withTransaction`) on a pinned write connection.
 - **Structural adapters** (`pgPool`, `mysqlPool`, `sqlitePool`) so the package depends on no driver —
   you bring your own `pg` / `mysql2` / `better-sqlite3` instance.
 
@@ -42,3 +43,74 @@ await db.close();
 
 `sqlite` (via `better-sqlite3`) applies WAL journaling and foreign-key enforcement and is inherently
 single-writer, matching platform-go.
+
+## Transactions
+
+`withTransaction` runs its callback on **one pinned connection from the write pool**. Resolving
+commits; rejecting rolls back and re-throws the original error unchanged.
+
+```ts
+const orderId = await db.withTransaction(async (q) => {
+  const { rows } = await q.query(
+    "INSERT INTO orders (total) VALUES ($1) RETURNING id",
+    [99],
+  );
+  await q.query("INSERT INTO order_events (order_id, kind) VALUES ($1, 'created')", [
+    rows[0].id,
+  ]);
+  return rows[0].id;
+});
+```
+
+The callback receives a bare `Queryable` — `query` and nothing else. It cannot commit, roll back,
+close the pool, or outlive the closure; that lifecycle belongs to `withTransaction`, which acquires
+the connection and releases it in a `finally`. `QueryablePool extends Queryable`, so a helper written
+against the narrow type takes either:
+
+```ts
+// Works with db.readPool, db.writePool, or the transaction's q.
+async function findOrder(q: Queryable, id: string) { … }
+```
+
+That is the seam the `outbox` port is built on: holding a `Queryable` handed out by
+`withTransaction` _means_ you are inside a transaction, so an enqueue cannot escape one by accident.
+
+Behaviour worth knowing:
+
+| situation                      | result                                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| callback resolves              | `COMMIT`; its value is returned                                                                        |
+| callback rejects               | `ROLLBACK`; the **original** error is re-thrown (a failed rollback is logged, not surfaced)            |
+| `COMMIT` fails                 | `TransactionCommitError` (`database/commit-failed`), driver error as `cause`; no rollback is attempted |
+| nested on the same client      | `NestedTransactionError` (`database/nested-transaction`) — there are no savepoints                     |
+| nested on a _different_ client | allowed; two databases share no commit and this package does not pretend otherwise                     |
+| write pool has no `connect()`  | `TransactionsUnsupportedError` (`database/transactions-unsupported`)                                   |
+
+Nesting is detected per async context, so concurrent transactions on one client — the normal case
+for a server handling many requests — are unaffected.
+
+Statements inside the callback can still be instrumented: `db.query(q, "…")` accepts the narrow
+`Queryable`.
+
+### Dialect notes
+
+`BEGIN` is issued by default, which postgres, mysql, and sqlite all accept. Override it with the
+`beginStatement` dep where the default locking mode is wrong — notably sqlite, where
+`BEGIN IMMEDIATE` takes the write lock up front instead of failing with `SQLITE_BUSY` when a
+deferred transaction tries to upgrade mid-flight:
+
+```ts
+const db = provideDatabase(
+  config,
+  { read: sqlitePool(raw) },
+  {
+    logger,
+    beginStatement: "BEGIN IMMEDIATE",
+  },
+);
+```
+
+`better-sqlite3` has a single connection and no nested transactions — a second `BEGIN` silently
+joins the first one's scope, and the first `COMMIT` commits both. `sqlitePool`'s `connect()` is
+therefore a write lock rather than a pool slot: concurrent `withTransaction` calls queue in arrival
+order instead of interleaving.

--- a/packages/database/src/adapters.ts
+++ b/packages/database/src/adapters.ts
@@ -1,10 +1,22 @@
-import type { QueryablePool, QueryResult } from "./database.js";
+import type { PooledConnection, QueryablePool, QueryResult } from "./database.js";
 
 /**
  * Adapters that normalize a driver's pool to {@link QueryablePool}. They are structurally typed, so
  * this package depends on no driver: the caller constructs `pg`/`mysql2`/`better-sqlite3` with the
  * connection string from `config.ts` and hands the instance here.
+ *
+ * Each adapter also supplies {@link QueryablePool.connect}, since a transaction is a pinned
+ * connection rather than a pool, and only the driver knows how to check one out.
  */
+
+/** The subset of a `node-postgres` `PoolClient` used here. */
+export interface PgClientLike {
+  query(
+    text: string,
+    params?: readonly unknown[],
+  ): Promise<{ rows: unknown[]; rowCount?: number | null }>;
+  release(): void;
+}
 
 /** The subset of a `node-postgres` `Pool` used here. */
 export interface PgPoolLike {
@@ -12,41 +24,97 @@ export interface PgPoolLike {
     text: string,
     params?: readonly unknown[],
   ): Promise<{ rows: unknown[]; rowCount?: number | null }>;
+  /** Absent only in a stand-in; a real `pg.Pool` always has it. */
+  connect?(): Promise<PgClientLike>;
   end(): Promise<void>;
+}
+
+function pgResult(raw: { rows: unknown[]; rowCount?: number | null }): QueryResult {
+  const result: QueryResult = { rows: raw.rows };
+  if (raw.rowCount != null) result.rowCount = raw.rowCount;
+  return result;
 }
 
 /** Adapts a `node-postgres` `Pool`. */
 export function pgPool(pool: PgPoolLike): QueryablePool {
-  return {
+  const adapted: QueryablePool = {
     async query(text, params): Promise<QueryResult> {
-      const raw = await pool.query(text, params);
-      const result: QueryResult = { rows: raw.rows };
-      if (raw.rowCount != null) result.rowCount = raw.rowCount;
-      return result;
+      return pgResult(await pool.query(text, params));
     },
     end: () => pool.end(),
   };
+  const connect = pool.connect?.bind(pool);
+  if (connect) {
+    adapted.connect = async (): Promise<PooledConnection> => {
+      const client = await connect();
+      let released = false;
+      return {
+        async query(text, params): Promise<QueryResult> {
+          return pgResult(await client.query(text, params));
+        },
+        // `pg` throws on a double release; guard so a release racing the pool's own error handling
+        // cannot turn cleanup into the error the caller sees.
+        release(): void {
+          if (released) return;
+          released = true;
+          client.release();
+        },
+      };
+    };
+  }
+  return adapted;
+}
+
+/** The subset of a `mysql2/promise` `PoolConnection` used here. */
+export interface MysqlConnectionLike {
+  query(sql: string, values?: readonly unknown[]): Promise<[unknown, unknown]>;
+  release(): void;
 }
 
 /** The subset of a `mysql2/promise` `Pool` used here. */
 export interface MysqlPoolLike {
   query(sql: string, values?: readonly unknown[]): Promise<[unknown, unknown]>;
+  /** Absent only in a stand-in; a real `mysql2/promise` `Pool` always has it. */
+  getConnection?(): Promise<MysqlConnectionLike>;
   end(): Promise<void>;
+}
+
+function mysqlResult(rows: unknown): QueryResult {
+  if (Array.isArray(rows)) return { rows };
+  const header = rows as { affectedRows?: number };
+  const result: QueryResult = { rows: [] };
+  if (typeof header.affectedRows === "number") result.rowCount = header.affectedRows;
+  return result;
 }
 
 /** Adapts a `mysql2/promise` `Pool`. Non-`SELECT` results (a header, not rows) yield empty `rows`. */
 export function mysqlPool(pool: MysqlPoolLike): QueryablePool {
-  return {
+  const adapted: QueryablePool = {
     async query(text, params): Promise<QueryResult> {
       const [rows] = await pool.query(text, params);
-      if (Array.isArray(rows)) return { rows };
-      const header = rows as { affectedRows?: number };
-      const result: QueryResult = { rows: [] };
-      if (typeof header.affectedRows === "number") result.rowCount = header.affectedRows;
-      return result;
+      return mysqlResult(rows);
     },
     end: () => pool.end(),
   };
+  const getConnection = pool.getConnection?.bind(pool);
+  if (getConnection) {
+    adapted.connect = async (): Promise<PooledConnection> => {
+      const connection = await getConnection();
+      let released = false;
+      return {
+        async query(text, params): Promise<QueryResult> {
+          const [rows] = await connection.query(text, params);
+          return mysqlResult(rows);
+        },
+        release(): void {
+          if (released) return;
+          released = true;
+          connection.release();
+        },
+      };
+    };
+  }
+  return adapted;
 }
 
 /** The subset of a `better-sqlite3` prepared statement used here. */
@@ -76,19 +144,50 @@ export function sqlitePool(
     db.pragma("journal_mode = WAL");
     db.pragma("foreign_keys = ON");
   }
+  // `async` so a synchronous `prepare` throw (invalid SQL) rejects the returned promise rather
+  // than escaping synchronously from this Promise-typed method.
+  const exec = async (
+    text: string,
+    params: readonly unknown[] = [],
+  ): Promise<QueryResult> => {
+    const statement = db.prepare(text);
+    // Only a row-returning statement (`reader === true`: SELECT, or `... RETURNING`) may use
+    // `all()`; a write is `reader === false` OR absent per SqliteStatementLike's contract, and
+    // calling `all()` on it throws in better-sqlite3. Route by truthiness so absent means write.
+    if (statement.reader) {
+      return { rows: statement.all(...params) };
+    }
+    const info = statement.run(...params);
+    return { rows: [], rowCount: info.changes };
+  };
+
+  // There is one connection, so "check one out" means "take the write lock". Without this a second
+  // concurrent transaction would interleave its BEGIN into the first one's scope and commit both at
+  // the first COMMIT — sqlite has no nested transactions to catch it. Callers queue instead.
+  let tail: Promise<void> = Promise.resolve();
+
   return {
-    // `async` so a synchronous `prepare` throw (invalid SQL) rejects the returned promise rather
-    // than escaping synchronously from this Promise-typed method.
-    async query(text, params = []): Promise<QueryResult> {
-      const statement = db.prepare(text);
-      // Only a row-returning statement (`reader === true`: SELECT, or `... RETURNING`) may use
-      // `all()`; a write is `reader === false` OR absent per SqliteStatementLike's contract, and
-      // calling `all()` on it throws in better-sqlite3. Route by truthiness so absent means write.
-      if (statement.reader) {
-        return { rows: statement.all(...params) };
-      }
-      const info = statement.run(...params);
-      return { rows: [], rowCount: info.changes };
+    query: exec,
+    async connect(): Promise<PooledConnection> {
+      let handOff!: () => void;
+      const held = new Promise<void>((resolve) => {
+        handOff = resolve;
+      });
+      const ahead = tail;
+      // Claim the slot synchronously, before the first await, so concurrent callers queue in
+      // arrival order rather than all racing on the same value of `tail`.
+      tail = ahead.then(() => held);
+      await ahead;
+
+      let released = false;
+      return {
+        query: exec,
+        release(): void {
+          if (released) return;
+          released = true;
+          handOff();
+        },
+      };
     },
     end(): Promise<void> {
       db.close();

--- a/packages/database/src/database.test.ts
+++ b/packages/database/src/database.test.ts
@@ -15,6 +15,8 @@ import {
   sqlitePool,
   writeConnectionString,
   DatabaseConfigSchema,
+  type PooledConnection,
+  type Queryable,
   type QueryablePool,
   type QueryResult,
 } from "./index.js";
@@ -64,6 +66,41 @@ function recordingLogger(): {
     withSpan: () => logger,
   };
   return { logger, errors };
+}
+
+interface TxPool extends QueryablePool {
+  /** Every statement issued on a pinned connection, in order. */
+  statements: string[];
+  checkouts: number;
+  releases: number;
+}
+
+/** A pool that pins a connection and records the transaction's statements and lifecycle. */
+function txPool(failOn: (text: string) => Error | undefined = () => undefined): TxPool {
+  const pool: TxPool = {
+    statements: [],
+    checkouts: 0,
+    releases: 0,
+    query: () => Promise.resolve({ rows: [] }),
+    end: () => Promise.resolve(),
+    connect(): Promise<PooledConnection> {
+      pool.checkouts += 1;
+      let released = false;
+      return Promise.resolve({
+        query(text): Promise<QueryResult> {
+          pool.statements.push(text);
+          const failure = failOn(text);
+          return failure ? Promise.reject(failure) : Promise.resolve({ rows: [] });
+        },
+        release(): void {
+          if (released) return;
+          released = true;
+          pool.releases += 1;
+        },
+      });
+    },
+  };
+  return pool;
 }
 
 describe("config", () => {
@@ -350,5 +387,456 @@ describe("adapters", () => {
     );
     // A synchronous throw from prepare would escape the Promise-typed method; assert it rejects.
     await expect(adapted.query("NOT SQL")).rejects.toThrow(/syntax error/);
+  });
+});
+
+describe("withTransaction", () => {
+  const config = { provider: "postgres", read: { database: "db" } } as const;
+
+  const client = (
+    write: QueryablePool,
+    deps: Parameters<typeof provideDatabase>[2] = {},
+  ): ReturnType<typeof provideDatabase> =>
+    provideDatabase(config, { read: probePool(), write }, deps);
+
+  it("wraps the callback in BEGIN/COMMIT and returns its value", async () => {
+    const write = txPool();
+    const db = client(write);
+
+    await expect(
+      db.withTransaction(async (q) => {
+        await q.query("INSERT INTO t VALUES ($1)", [1]);
+        return "ok";
+      }),
+    ).resolves.toBe("ok");
+
+    expect(write.statements).toStrictEqual([
+      "BEGIN",
+      "INSERT INTO t VALUES ($1)",
+      "COMMIT",
+    ]);
+  });
+
+  it("rolls back and re-throws the callback's error unchanged", async () => {
+    const write = txPool();
+    const boom = new Error("callback failed");
+
+    await expect(
+      client(write).withTransaction(async (q) => {
+        await q.query("INSERT INTO t VALUES ($1)", [1]);
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(write.statements).toStrictEqual([
+      "BEGIN",
+      "INSERT INTO t VALUES ($1)",
+      "ROLLBACK",
+    ]);
+  });
+
+  // A transaction on a read replica either errors or silently discards its writes, so the read
+  // pool must not be touched even when it is the one that was configured first.
+  it("runs on the write pool, never the read pool", async () => {
+    const read = probePool();
+    const write = txPool();
+    const db = provideDatabase(config, { read, write });
+
+    await db.withTransaction(async (q) => {
+      await q.query("UPDATE t SET n = 1");
+    });
+
+    expect(write.checkouts).toBe(1);
+    expect(read.calls()).toBe(0);
+  });
+
+  it("releases the connection on commit, on rollback, and when BEGIN itself fails", async () => {
+    const committed = txPool();
+    await client(committed).withTransaction(async () => undefined);
+    expect(committed).toMatchObject({ checkouts: 1, releases: 1 });
+
+    const rolledBack = txPool();
+    await expect(
+      client(rolledBack).withTransaction(() => Promise.reject(new Error("no"))),
+    ).rejects.toThrow("no");
+    expect(rolledBack).toMatchObject({ checkouts: 1, releases: 1 });
+
+    // BEGIN failing means there is no transaction to roll back, but there is still a connection
+    // checked out — the case a `finally`-less implementation leaks.
+    const cannotBegin = txPool((text) =>
+      text === "BEGIN" ? new Error("cannot begin") : undefined,
+    );
+    await expect(
+      client(cannotBegin).withTransaction(async () => undefined),
+    ).rejects.toThrow("cannot begin");
+    expect(cannotBegin.statements).toStrictEqual(["BEGIN"]);
+    expect(cannotBegin).toMatchObject({ checkouts: 1, releases: 1 });
+  });
+
+  it("leaks no connection across many sequential transactions, half of which fail", async () => {
+    const write = txPool();
+    const db = client(write);
+
+    for (let i = 0; i < 100; i += 1) {
+      const attempt = db.withTransaction(async (q) => {
+        await q.query("SELECT 1");
+        if (i % 2 === 0) throw new Error(`failure ${String(i)}`);
+      });
+      if (i % 2 === 0) await expect(attempt).rejects.toThrow(`failure ${String(i)}`);
+      else await attempt;
+    }
+
+    expect(write.checkouts).toBe(100);
+    expect(write.releases).toBe(100);
+  });
+
+  // The error that caused the rollback is the diagnosis; the cleanup failure is a footnote. Losing
+  // the former to report the latter is the bug this guards.
+  it("preserves the original error when the rollback itself fails, and logs the rollback", async () => {
+    const write = txPool((text) =>
+      text === "ROLLBACK" ? new Error("connection reset") : undefined,
+    );
+    const { logger, errors } = recordingLogger();
+    const boom = new Error("callback failed");
+
+    await expect(
+      client(write, { logger }).withTransaction(() => Promise.reject(boom)),
+    ).rejects.toBe(boom);
+
+    expect(write.releases).toBe(1);
+    const rollbackLine = errors.find((e) => e.msg === "rolling back transaction");
+    expect((rollbackLine?.err as Error).message).toBe("connection reset");
+    expect(rollbackLine?.values).toMatchObject({ rollbackCause: "callback failed" });
+  });
+
+  // A failed commit leaves the outcome unknown, which is a different fact from "the callback threw"
+  // — and the driver has already ended the transaction, so a rollback would only raise a spurious
+  // "no transaction in progress".
+  it("reports a failed commit as TransactionCommitError and attempts no rollback", async () => {
+    const write = txPool((text) =>
+      text === "COMMIT" ? new Error("deadlock detected") : undefined,
+    );
+
+    await expect(
+      client(write).withTransaction(async () => "value"),
+    ).rejects.toMatchObject({
+      code: "database/commit-failed",
+      cause: { message: "deadlock detected" },
+    });
+
+    expect(write.statements).toStrictEqual(["BEGIN", "COMMIT"]);
+    expect(write.releases).toBe(1);
+  });
+
+  it("refuses a pool that cannot pin a connection", async () => {
+    // probePool has no connect(); spreading statements across arbitrary pooled connections would
+    // look like it worked, so this fails loudly instead.
+    await expect(
+      client(probePool()).withTransaction(async () => undefined),
+    ).rejects.toMatchObject({ code: "database/transactions-unsupported" });
+  });
+
+  it("hands the callback a bare Queryable with no lifecycle surface", async () => {
+    const write = txPool();
+    let received: Queryable | undefined;
+    await client(write).withTransaction(async (q) => {
+      received = q;
+    });
+
+    expect(received).toBeDefined();
+    expect("release" in received!).toBe(false);
+    expect("end" in received!).toBe(false);
+    expect("connect" in received!).toBe(false);
+  });
+
+  it("honours a dialect-specific begin statement", async () => {
+    const write = txPool();
+    await client(write, { beginStatement: "BEGIN IMMEDIATE" }).withTransaction(
+      async () => undefined,
+    );
+    expect(write.statements[0]).toBe("BEGIN IMMEDIATE");
+  });
+
+  it("instruments statements issued inside the transaction", async () => {
+    const write = txPool();
+    const db = client(write);
+    const rows = await db.withTransaction((q) => db.query(q, "SELECT 1"));
+    expect(rows).toStrictEqual({ rows: [] });
+    expect(write.statements).toStrictEqual(["BEGIN", "SELECT 1", "COMMIT"]);
+  });
+
+  describe("nesting", () => {
+    it("refuses to nest on the same client, and still releases the outer connection", async () => {
+      const write = txPool();
+      const db = client(write);
+
+      await expect(
+        db.withTransaction(async () => {
+          await db.withTransaction(async () => undefined);
+        }),
+      ).rejects.toMatchObject({ code: "database/nested-transaction" });
+
+      // The inner call never checked a connection out; the outer one rolled back and released.
+      expect(write).toMatchObject({ checkouts: 1, releases: 1 });
+      expect(write.statements).toStrictEqual(["BEGIN", "ROLLBACK"]);
+    });
+
+    it("detects a nest that happens after an await", async () => {
+      const write = txPool();
+      const db = client(write);
+
+      await expect(
+        db.withTransaction(async (q) => {
+          await q.query("SELECT 1");
+          await db.withTransaction(async () => undefined);
+        }),
+      ).rejects.toMatchObject({ code: "database/nested-transaction" });
+    });
+
+    // The reason detection is async-context-scoped rather than a boolean on the client: two
+    // requests transacting at once are the normal case, not a nesting violation.
+    it("allows genuinely concurrent transactions on the same client", async () => {
+      const write = txPool();
+      const db = client(write);
+      let releaseFirst!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+
+      const first = db.withTransaction(async (q) => {
+        await gate;
+        await q.query("first");
+        return 1;
+      });
+      const second = db.withTransaction(async (q) => {
+        await q.query("second");
+        releaseFirst();
+        return 2;
+      });
+
+      await expect(Promise.all([first, second])).resolves.toStrictEqual([1, 2]);
+      expect(write).toMatchObject({ checkouts: 2, releases: 2 });
+    });
+
+    // Two databases share no commit. Refusing this would not make the write atomic, it would only
+    // stop the caller expressing what they already have to reason about themselves.
+    it("allows a different client's transaction inside this one", async () => {
+      const outer = txPool();
+      const inner = txPool();
+      const outerDb = client(outer);
+      const innerDb = client(inner);
+
+      await outerDb.withTransaction(async () => {
+        await innerDb.withTransaction(async (q) => {
+          await q.query("INSERT INTO other VALUES (1)");
+        });
+      });
+
+      expect(outer.statements).toStrictEqual(["BEGIN", "COMMIT"]);
+      expect(inner.statements).toStrictEqual([
+        "BEGIN",
+        "INSERT INTO other VALUES (1)",
+        "COMMIT",
+      ]);
+    });
+  });
+});
+
+/**
+ * A driver stand-in wired through its real adapter, so the conformance suite below exercises the
+ * adapter's own checkout/release path rather than a hand-written pool.
+ */
+interface DriverProbe {
+  pool: QueryablePool;
+  statements: string[];
+  /** Connections checked out but not yet released. */
+  open: () => number;
+}
+
+function pgProbe(): DriverProbe {
+  const statements: string[] = [];
+  let open = 0;
+  const pool = pgPool({
+    query: (text) => {
+      statements.push(text);
+      return Promise.resolve({ rows: [], rowCount: null });
+    },
+    connect: () => {
+      open += 1;
+      return Promise.resolve({
+        query: (text) => {
+          statements.push(text);
+          return Promise.resolve({ rows: [], rowCount: null });
+        },
+        release: () => {
+          open -= 1;
+        },
+      });
+    },
+    end: () => Promise.resolve(),
+  });
+  return { pool, statements, open: () => open };
+}
+
+function mysqlProbe(): DriverProbe {
+  const statements: string[] = [];
+  let open = 0;
+  const pool = mysqlPool({
+    query: (sql) => {
+      statements.push(sql);
+      return Promise.resolve([[], undefined]);
+    },
+    getConnection: () => {
+      open += 1;
+      return Promise.resolve({
+        query: (sql) => {
+          statements.push(sql);
+          return Promise.resolve([[], undefined]);
+        },
+        release: () => {
+          open -= 1;
+        },
+      });
+    },
+    end: () => Promise.resolve(),
+  });
+  return { pool, statements, open: () => open };
+}
+
+function sqliteProbe(): DriverProbe {
+  const statements: string[] = [];
+  const pool = sqlitePool(
+    {
+      prepare: (sql: string) => ({
+        reader: sql.startsWith("SELECT"),
+        all: () => {
+          statements.push(sql);
+          return [];
+        },
+        run: () => {
+          statements.push(sql);
+          return { changes: 0 };
+        },
+      }),
+      pragma: () => undefined,
+      close: () => undefined,
+    },
+    { applyPragmas: false },
+  );
+  // better-sqlite3 has one connection; the adapter's checkout is a lock, not a pool slot, so
+  // there is no driver-side counter to read. Leak-freedom is asserted below by the fact that a
+  // hundred sequential transactions all complete rather than deadlocking on a leaked slot.
+  return { pool, statements, open: () => 0 };
+}
+
+/**
+ * Provider-agnostic transaction conformance. Running the same assertions through each adapter
+ * proves `withTransaction` is dialect-independent, and that every adapter's `connect()` really
+ * pins a connection and gives it back.
+ */
+describe.each([
+  ["postgres", pgProbe],
+  ["mysql", mysqlProbe],
+  ["sqlite", sqliteProbe],
+] as const)("withTransaction conformance: %s", (provider, makeProbe) => {
+  const db = (probe: DriverProbe): ReturnType<typeof provideDatabase> =>
+    provideDatabase({ provider, read: { database: "db" } }, { read: probe.pool });
+
+  it("commits the callback's statements", async () => {
+    const probe = makeProbe();
+    await db(probe).withTransaction(async (q) => {
+      await q.query("INSERT INTO t VALUES (1)");
+    });
+    expect(probe.statements).toStrictEqual([
+      "BEGIN",
+      "INSERT INTO t VALUES (1)",
+      "COMMIT",
+    ]);
+    expect(probe.open()).toBe(0);
+  });
+
+  it("rolls back and re-throws", async () => {
+    const probe = makeProbe();
+    const boom = new Error("nope");
+    await expect(
+      db(probe).withTransaction(async (q) => {
+        await q.query("INSERT INTO t VALUES (1)");
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+    expect(probe.statements).toStrictEqual([
+      "BEGIN",
+      "INSERT INTO t VALUES (1)",
+      "ROLLBACK",
+    ]);
+    expect(probe.open()).toBe(0);
+  });
+
+  it("holds nothing across a hundred sequential transactions", async () => {
+    const probe = makeProbe();
+    const client = db(probe);
+    for (let i = 0; i < 100; i += 1) {
+      await client.withTransaction(async (q) => {
+        await q.query("SELECT 1");
+      });
+    }
+    expect(probe.open()).toBe(0);
+    expect(probe.statements).toHaveLength(300);
+  });
+});
+
+// sqlite's semantics differ enough to be worth asserting rather than assuming: one connection, no
+// nested transactions, and no error if a second BEGIN lands inside the first one's scope — it just
+// silently joins it, and the first COMMIT commits both.
+describe("sqlite transaction semantics", () => {
+  it("serializes concurrent transactions instead of interleaving them", async () => {
+    const probe = sqliteProbe();
+    const client = provideDatabase(
+      { provider: "sqlite", read: { database: ":memory:" } },
+      { read: probe.pool },
+    );
+
+    const runs = ["a", "b", "c"].map((name) =>
+      client.withTransaction(async (q) => {
+        await q.query(`INSERT INTO t VALUES ('${name}')`);
+        // Yield twice, so an unserialized implementation would certainly interleave here.
+        await Promise.resolve();
+        await q.query(`UPDATE t SET n = 1 WHERE v = '${name}'`);
+      }),
+    );
+    await Promise.all(runs);
+
+    expect(probe.statements).toStrictEqual([
+      "BEGIN",
+      "INSERT INTO t VALUES ('a')",
+      "UPDATE t SET n = 1 WHERE v = 'a'",
+      "COMMIT",
+      "BEGIN",
+      "INSERT INTO t VALUES ('b')",
+      "UPDATE t SET n = 1 WHERE v = 'b'",
+      "COMMIT",
+      "BEGIN",
+      "INSERT INTO t VALUES ('c')",
+      "UPDATE t SET n = 1 WHERE v = 'c'",
+      "COMMIT",
+    ]);
+  });
+
+  it("hands the lock back when a transaction fails, so the next one is not blocked", async () => {
+    const probe = sqliteProbe();
+    const client = provideDatabase(
+      { provider: "sqlite", read: { database: ":memory:" } },
+      { read: probe.pool },
+    );
+
+    await expect(
+      client.withTransaction(() => Promise.reject(new Error("first failed"))),
+    ).rejects.toThrow("first failed");
+    await expect(
+      client.withTransaction(async (q) => {
+        await q.query("SELECT 1");
+        return "second ran";
+      }),
+    ).resolves.toBe("second ran");
   });
 });

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -1,3 +1,5 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
 import { PlatformError } from "@primandproper/errors";
 import {
   makeObserver,
@@ -33,13 +35,39 @@ export interface QueryResult {
 }
 
 /**
+ * Anything statements can be issued through: a pool, or the pinned connection a transaction runs
+ * on. It is deliberately the *whole* surface — no `end()`, no commit, no rollback — so a function
+ * written against `Queryable` composes with either, and holding one inside
+ * {@link DatabaseClient.withTransaction} grants no way to end the transaction or the pool.
+ */
+export interface Queryable {
+  query(text: string, params?: readonly unknown[]): Promise<QueryResult>;
+}
+
+/**
+ * A connection checked out of a pool and pinned for the life of a transaction. Returned by
+ * {@link QueryablePool.connect} and released by {@link DatabaseClient.withTransaction}, never by
+ * the caller — which is why it never reaches the transaction callback.
+ */
+export interface PooledConnection extends Queryable {
+  /** Returns the connection to its pool. Idempotent in every adapter here. */
+  release(): void | Promise<void>;
+}
+
+/**
  * The minimal pool surface this package instruments — the seam a query builder (Drizzle/Kysely) or
  * raw SQL sits on. Driver pools are adapted to it by the functions in `adapters.ts`.
  */
-export interface QueryablePool {
-  query(text: string, params?: readonly unknown[]): Promise<QueryResult>;
+export interface QueryablePool extends Queryable {
   /** Drains and closes the pool. */
   end(): Promise<void>;
+  /**
+   * Checks out a connection pinned to the caller. Optional because the seam is structural: a pool
+   * that cannot pin a connection cannot run a transaction, and {@link DatabaseClient.withTransaction}
+   * rejects with {@link TransactionsUnsupportedError} rather than silently spreading the statements
+   * across arbitrary pooled connections — which is the failure that looks like it worked.
+   */
+  connect?(): Promise<PooledConnection>;
 }
 
 /**
@@ -62,12 +90,34 @@ export interface DatabaseClient {
   close(): Promise<void>;
   /** The client's notion of "now", injectable for tests. */
   currentTime(): Date;
-  /** Runs a statement on `pool` inside an observability span. */
+  /**
+   * Runs a statement on `target` inside an observability span. Accepts the narrow {@link Queryable},
+   * so statements issued inside {@link withTransaction} are instrumented the same way pool queries are.
+   */
   query(
-    pool: QueryablePool,
+    target: Queryable,
     text: string,
     params?: readonly unknown[],
   ): Promise<QueryResult>;
+  /**
+   * Runs `fn` inside a single transaction on the **write** pool, on one pinned connection.
+   * Resolving commits; rejecting rolls back and re-throws the original error unchanged.
+   *
+   * `fn` receives a bare {@link Queryable} and nothing else: it cannot commit, roll back, close
+   * the pool, or outlive the closure. Lifecycle belongs to this method, which acquires the
+   * connection and releases it in a `finally` — including when the rollback itself fails.
+   *
+   * Nesting is **not** supported and throws {@link NestedTransactionError} rather than silently
+   * flattening two scopes into one (there are no savepoints). Detection is per async context, so
+   * genuinely concurrent transactions on the same client are unaffected, and nesting a *different*
+   * client's transaction inside this one is allowed — two databases have no shared commit and this
+   * package does not pretend otherwise.
+   *
+   * A failed commit throws {@link TransactionCommitError} and does not attempt a rollback: the
+   * driver has already ended the transaction and returned the connection, so a second attempt would
+   * only surface a spurious "no transaction in progress".
+   */
+  withTransaction<T>(fn: (q: Queryable) => Promise<T>): Promise<T>;
 }
 
 /** Thrown when a client is used before its pools are reachable. */
@@ -78,6 +128,47 @@ export class DatabaseNotReadyError extends PlatformError {
   }
 }
 
+/** Thrown by {@link DatabaseClient.withTransaction} when the write pool cannot pin a connection. */
+export class TransactionsUnsupportedError extends PlatformError {
+  constructor(provider: string) {
+    super(
+      "database/transactions-unsupported",
+      `the ${provider} write pool does not expose connect(), so it cannot run a transaction`,
+    );
+    this.name = "TransactionsUnsupportedError";
+  }
+}
+
+/** Thrown when {@link DatabaseClient.withTransaction} is called inside its own transaction. */
+export class NestedTransactionError extends PlatformError {
+  constructor() {
+    super(
+      "database/nested-transaction",
+      "withTransaction cannot be nested on the same client; savepoints are not supported",
+    );
+    this.name = "NestedTransactionError";
+  }
+}
+
+/**
+ * Thrown when `COMMIT` fails. Distinct from an error thrown by the callback because the outcome is
+ * different in kind: the callback's work provably did not land, whereas a failed commit leaves the
+ * transaction's fate unknown to this process. The driver error is the `cause`.
+ */
+export class TransactionCommitError extends PlatformError {
+  constructor(cause: Error) {
+    super("database/commit-failed", "committing transaction", { cause });
+    this.name = "TransactionCommitError";
+  }
+}
+
+/**
+ * The clients whose transactions are open in the current async context. Async-context-scoped rather
+ * than a field on the client, because a per-instance flag would call two concurrent requests a
+ * nesting violation — the common case — while still missing a genuine nest across an `await`.
+ */
+const openTransactions = new AsyncLocalStorage<ReadonlySet<DatabaseClient>>();
+
 /** Observability plus the injectable runtime knobs the client uses. */
 export interface DatabaseClientDeps extends ObservabilityDeps {
   /** Overrides `Date` for {@link DatabaseClient.currentTime}; injectable for tests. */
@@ -86,6 +177,13 @@ export interface DatabaseClientDeps extends ObservabilityDeps {
   sleep?: (ms: number) => Promise<void>;
   /** The statement used to probe readiness. Defaults to `SELECT 1`. */
   pingQuery?: string;
+  /**
+   * The statement that opens a transaction. Defaults to `BEGIN`, which postgres, mysql, and sqlite
+   * all accept. Override it where the dialect's default locking mode is wrong for the workload —
+   * sqlite's `BEGIN IMMEDIATE` takes the write lock up front instead of failing with `SQLITE_BUSY`
+   * when a deferred transaction tries to upgrade mid-flight.
+   */
+  beginStatement?: string;
 }
 
 class InstrumentedClient implements DatabaseClient {
@@ -97,6 +195,7 @@ class InstrumentedClient implements DatabaseClient {
   readonly #now: () => Date;
   readonly #sleep: (ms: number) => Promise<void>;
   readonly #pingQuery: string;
+  readonly #beginStatement: string;
 
   constructor(
     readPool: QueryablePool,
@@ -112,6 +211,7 @@ class InstrumentedClient implements DatabaseClient {
     this.#now = deps.now ?? ((): Date => new Date());
     this.#sleep = deps.sleep ?? defaultSleep;
     this.#pingQuery = deps.pingQuery ?? "SELECT 1";
+    this.#beginStatement = deps.beginStatement ?? "BEGIN";
   }
 
   async isReady(): Promise<boolean> {
@@ -185,14 +285,14 @@ class InstrumentedClient implements DatabaseClient {
   }
 
   async query(
-    pool: QueryablePool,
+    target: Queryable,
     text: string,
     params?: readonly unknown[],
   ): Promise<QueryResult> {
     const op = this.#observer.begin(`${o11yName}.query`);
     try {
       op.set("db.system", this.#config.provider).set("db.statement", text);
-      const result = await pool.query(text, params);
+      const result = await target.query(text, params);
       op.set("db.rows", result.rows.length);
       return result;
     } catch (error) {
@@ -200,6 +300,80 @@ class InstrumentedClient implements DatabaseClient {
       throw error;
     } finally {
       op.end();
+    }
+  }
+
+  async withTransaction<T>(fn: (q: Queryable) => Promise<T>): Promise<T> {
+    const enclosing = openTransactions.getStore();
+    if (enclosing?.has(this)) throw new NestedTransactionError();
+
+    // The write pool only. A transaction on the read pool targets a replica, where it either fails
+    // outright or reads a stale snapshot and discards every write in it.
+    const pool = this.writePool;
+    if (typeof pool.connect !== "function") {
+      throw new TransactionsUnsupportedError(this.#config.provider);
+    }
+
+    const op = this.#observer.begin(`${o11yName}.withTransaction`);
+    op.set("db.system", this.#config.provider);
+    let connection: PooledConnection | undefined;
+    try {
+      connection = await pool.connect();
+      await connection.query(this.#beginStatement);
+      const pinned = connection;
+
+      let value: T;
+      try {
+        // Re-wrap rather than passing `pinned` straight through: the connection carries `release()`,
+        // and the callback holding an object it must not call is a weaker guarantee than it not
+        // holding one at all.
+        const scope = new Set(enclosing ?? []).add(this);
+        value = await openTransactions.run(scope, () =>
+          fn({ query: (text, params) => pinned.query(text, params) }),
+        );
+      } catch (error) {
+        await this.#rollback(pinned, toError(error));
+        throw error;
+      }
+
+      try {
+        await pinned.query("COMMIT");
+      } catch (error) {
+        throw new TransactionCommitError(toError(error));
+      }
+      return value;
+    } catch (error) {
+      op.error(toError(error), "transaction failed");
+      throw error;
+    } finally {
+      // Release even when BEGIN, the callback, the rollback, or the commit failed — one connection
+      // leaked per transaction exhausts the pool, and presents as unrelated latency far from here.
+      if (connection !== undefined) await this.#release(connection);
+      op.end();
+    }
+  }
+
+  /**
+   * Rolls back, swallowing any failure. The error that caused the rollback is what the caller needs;
+   * replacing it with the cleanup failure would discard the diagnosis, so the cleanup failure is
+   * logged with its cause attached instead.
+   */
+  async #rollback(connection: PooledConnection, cause: Error): Promise<void> {
+    try {
+      await connection.query("ROLLBACK");
+    } catch (err) {
+      this.#logger.error("rolling back transaction", toError(err), {
+        rollbackCause: cause.message,
+      });
+    }
+  }
+
+  /** Releases the connection, logging rather than throwing so it cannot mask the caller's error. */
+  async #release(connection: PooledConnection): Promise<void> {
+    try {
+      await connection.release();
+    } catch (err) {
+      this.#logger.error("releasing transaction connection", toError(err));
     }
   }
 }


### PR DESCRIPTION
Closes #7.

Gives `DatabaseClient` a way to run several statements in one transaction, and hands the callback something it can issue them through. This is the hard prerequisite for the `outbox` port (#10) — that guarantee rests entirely on the event insert being *a statement in the caller's transaction*.

## The shape

```ts
const orderId = await db.withTransaction(async (q) => {
  const { rows } = await q.query("INSERT INTO orders (total) VALUES ($1) RETURNING id", [99]);
  await q.query("INSERT INTO order_events (order_id, kind) VALUES ($1, 'created')", [rows[0].id]);
  return rows[0].id;
});
```

The callback receives a bare `Queryable` — `query` and nothing else. It cannot commit, roll back, close the pool, or outlive the closure. It is re-wrapped rather than handed the connection directly, because "the callback holds an object it must not call" is a weaker guarantee than it not holding one at all.

`QueryablePool extends Queryable`, so a helper written against the narrow type takes either — which is what lets `outbox.enqueue(q, …)` make *holding* a `Queryable` mean *being inside* a transaction. `DatabaseClient.query` widened to `Queryable` for the same reason, so statements inside a transaction are instrumented like any other.

## Pinning the connection

A transaction is a pinned connection, not a pool, and only the driver knows how to check one out — so `QueryablePool` gains an optional `connect(): Promise<PooledConnection>` and each adapter supplies it: `pool.connect()` for pg, `getConnection()` for mysql, and a **write lock** for sqlite, which has one connection and no nested transactions (a second `BEGIN` silently joins the first one's scope and the first `COMMIT` commits both).

A pool that cannot pin one throws `TransactionsUnsupportedError` rather than spreading the statements across arbitrary pooled connections — the failure that looks like it worked. Write pool only; a transaction on a read replica either errors or discards its writes.

The connection is released in a `finally` — including when `BEGIN`, the callback, the rollback, or the commit failed. One leaked connection per transaction exhausts the pool and presents as unrelated latency far from here.

## Decisions worth a look

| situation | result |
|---|---|
| callback rejects | `ROLLBACK`, **original** error re-thrown; a failed rollback is logged, never substituted for the error that caused it |
| `COMMIT` fails | `TransactionCommitError` (`database/commit-failed`), driver error as `cause`, **no** second rollback — the driver already ended the transaction, so it would only raise a spurious "no transaction in progress" |
| nested on same client | `NestedTransactionError` — throws rather than flattening two scopes; there are no savepoints |
| nested on a *different* client | **allowed** — two databases share no commit, and refusing would not make the write atomic |

Nesting detection is async-context-scoped (`AsyncLocalStorage`) rather than a flag on the client. A per-instance boolean would call two concurrent requests a nesting violation — the common case — while still missing a genuine nest across an `await`. Both are asserted.

`BEGIN` is the default and all three dialects accept it; a `beginStatement` dep (alongside the existing `pingQuery`) covers sqlite's `BEGIN IMMEDIATE`.

## Tests

48 passing. A provider-agnostic conformance suite runs commit/rollback/no-leak through each of the three real adapters, so it exercises their own checkout–release path rather than a hand-written pool. Plus targeted tests for: no leak across 100 sequential transactions (half of them failing), rollback preserving the original error, commit failure, `BEGIN` failure still releasing, the callback's surface having no `release`/`end`/`connect`, and sqlite serializing three concurrent transactions instead of interleaving them.

Each of the three load-bearing behaviours was mutation-checked — removing the sqlite lock, the `finally` release, and the nesting guard each fails exactly the tests that claim them.

Repo-wide `turbo typecheck test build` is green (105/105). Untouched: the untracked `packages/authorization/` WIP, which fails typecheck on `main` already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhrZu2juqReVTho9PWQ5e