### PR TITLE
feat(idempotency): port from platform-go v8

### DIFF
--- a/.changeset/idempotency-port.md
+++ b/.changeset/idempotency-port.md
@@ -17,9 +17,11 @@ execution that outlived its claim cannot overwrite whoever re-claimed the key �
 The four outcomes are a discriminated union (`executed` / `replayed` / `in-flight` /
 `fingerprint-mismatch`) rather than thrown sentinels: they are expected control flow, and this
 matches the repo's optional-over-sentinels stance. Thrown `PlatformError`s are reserved for
-genuine failures. Store failure is `fail-closed` by default, `fail-open` opt-in, and — diverging
-from platform-go, which applies it to reads only — the policy covers claim writes and lock
-failures too, so `fail-open` means what its name says.
+genuine failures. Store failure is `fail-closed` by default with `fail-open` opt-in, and the
+policy governs **reads only**, as in platform-go: a failed read can be treated as a miss and
+carried on from, while a claim that could not be written leaves the completion nothing to prove
+ownership against, so a failed claim write or an unreachable locker refuses the request under
+either policy.
 
 The package is isomorphic with a deliberately asymmetric split: the browser entry carries key
 minting, fingerprinting, and an `idempotentFetch` wrapper that binds one key to the wrapper (so

--- a/.changeset/idempotency-port.md
+++ b/.changeset/idempotency-port.md
@@ -1,0 +1,31 @@
+---
+"@primandproper/idempotency": minor
+---
+
+Add `@primandproper/idempotency`, the port of platform-go's `idempotency`: work runs at most once
+per client-supplied key, so a retry of a request whose response was never seen replays the
+recorded result instead of charging the card twice.
+
+The manager implements the four-step claim protocol exactly — read, then lock/re-read/claim/
+unlock, then run the work **outside** the lock, then record or release. The re-read inside the
+lock is what makes it correct, and the work stays outside it because a held lock is a held
+resource (the postgres provider holds a transaction), lock leases are shorter than real work, and
+a lock leaves no evidence when a process dies mid-execution. Claims carry an owner id, so an
+execution that outlived its claim cannot overwrite whoever re-claimed the key —
+`idempotency.claims.lost` counts that and is the counter to alert on.
+
+The four outcomes are a discriminated union (`executed` / `replayed` / `in-flight` /
+`fingerprint-mismatch`) rather than thrown sentinels: they are expected control flow, and this
+matches the repo's optional-over-sentinels stance. Thrown `PlatformError`s are reserved for
+genuine failures. Store failure is `fail-closed` by default, `fail-open` opt-in, and — diverging
+from platform-go, which applies it to reads only — the policy covers claim writes and lock
+failures too, so `fail-open` means what its name says.
+
+The package is isomorphic with a deliberately asymmetric split: the browser entry carries key
+minting, fingerprinting, and an `idempotentFetch` wrapper that binds one key to the wrapper (so
+building it inside a retry loop is the visible mistake), while the Node entry adds the manager. A
+browser has no record store or lock, and a noop stand-in would be idempotency that looks wired up
+and guarantees nothing.
+
+Also exports `withLock`, a scoped acquire/run/release helper over `DistributedLock` that reports
+contention as a value rather than throwing.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ logic, one build), **isomorphic** (same import resolves per-environment), **serv
 | `@primandproper/eventstream`   | `EventStream` over SSE and WebSocket                                    |
 | `@primandproper/analytics`     | `EventReporter` interface with swappable providers                      |
 | `@primandproper/eventcapture`  | Non-blocking high-volume event capture draining to a swappable sink     |
+| `@primandproper/idempotency`   | At-most-once execution per client key (manager on Node, keys in either) |
 
 ### Server-only
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,33 @@ export default tseslint.config(
     },
   },
   {
+    // idempotency is isomorphic with an asymmetric split: the client half (key minting,
+    // fingerprints, the fetch wrapper) ships to the browser, while the manager is `*.node.ts`
+    // because it needs a record store and a distributed lock. The server-only packages are
+    // banned alongside the Node built-ins so the shared core cannot quietly grow an import that
+    // would drag a Redis client into a browser bundle.
+    files: ["packages/idempotency/src/**/*.ts"],
+    ignores: [
+      "packages/idempotency/src/**/*.node.ts",
+      "packages/idempotency/src/**/*.test.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            ...nodeBuiltinBan.patterns,
+            {
+              group: ["@primandproper/distributedlock", "@primandproper/database"],
+              message:
+                "Server-only packages belong in idempotency's `*.node.ts` half — the rest of this package ships to the browser.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -1,0 +1,223 @@
+# @primandproper/idempotency
+
+Runs work at most once per client-supplied key — the TypeScript port of platform-go's
+`idempotency`.
+
+It exists for the case where a client sends a request, never sees the response, retries, and the
+work in between spent real money. Without a key the server cannot tell that second request apart
+from a deliberate second purchase, so it charges the card twice.
+
+## The client mints the key
+
+This is the part most often read backwards. **The server never issues a key.** The client
+generates one before its first attempt and reuses that same value on every retry of the same
+logical operation:
+
+```ts
+import { idempotentFetch } from "@primandproper/idempotency";
+
+const send = idempotentFetch(); // mints ONE key, OUTSIDE the retry loop
+
+await policy.run(() => send("/charges", { method: "POST", body }));
+```
+
+The wrapper _is_ the key — that shape is deliberate. A key minted inside the retry loop is a new
+key per attempt, which looks like protection and provides none; nothing on the server can detect
+the mistake, because a retry and a deliberate duplicate are byte-identical. Making the key belong
+to a wrapper you construct means the mistake is at least visible: the construction is what moved.
+
+There is no round trip to acquire a key, because a request that times out never returns anything.
+
+## What it guarantees
+
+At-most-once **effect**, not exactly-once. The gap is worth naming:
+
+- a recorded result is **replayed** instead of re-run;
+- work that started and has not reported back is **refused**, because "did it happen?" is
+  unanswerable and running it again is the worse guess;
+- a key reused for a _different_ request is reported as a **mismatch** rather than answered with
+  the earlier result.
+
+What it cannot promise: work that has its effect and _then_ fails. The charge landed, the error
+came back, nothing was recorded, and the retry charges again. Recording failures instead would be
+worse — a transient error would be pinned for the whole TTL and the client could never succeed.
+That is what `recordable` is for: a caller can say "that failure was ours, not theirs".
+
+## Server side
+
+```ts
+import { provideCache } from "@primandproper/cache";
+import { provideDistributedLock } from "@primandproper/distributedlock";
+import {
+  fingerprintRequest,
+  parseIdempotencyKey,
+  provideIdempotencyManager,
+  IDEMPOTENCY_KEY_HEADER,
+  type IdempotencyRecord,
+} from "@primandproper/idempotency";
+
+interface Receipt {
+  chargeId: string;
+  charged: boolean;
+}
+
+const manager = provideIdempotencyManager<Receipt>(
+  { inFlightTtlMs: 120_000, ttlMs: 86_400_000 },
+  {
+    store: provideCache<IdempotencyRecord<Receipt>>({
+      provider: "redis",
+      redis: { url },
+    }),
+    lock: provideDistributedLock({ provider: "redis", redis: { url } }),
+    recordable: (receipt) => receipt.charged,
+    logger,
+  },
+);
+
+const key = parseIdempotencyKey(req.headers.get(IDEMPOTENCY_KEY_HEADER) ?? "");
+const fingerprint = await fingerprintRequest({
+  method: req.method,
+  url: req.url,
+  principal: user.id,
+  body,
+});
+
+const result = await manager.run(key, fingerprint, () => charge(body));
+switch (result.status) {
+  case "executed":
+  case "replayed":
+    return json(result.value);
+  case "in-flight":
+    return status(409); // retry later; the answer is not knowable yet
+  case "fingerprint-mismatch":
+    return status(422); // a client bug, not a retry
+}
+```
+
+The four outcomes are **returned, not thrown**: they are expected control flow, and the
+discriminated union fits this repo's optional-over-sentinels stance better than Go's error
+sentinels. Thrown `PlatformError`s (`idempotency/*` codes) are reserved for genuine failures — an
+unusable key, an empty fingerprint, an unreachable record store under `fail-closed`.
+
+## The claim protocol
+
+1. read the record — replay, refuse, or continue;
+2. lock → **re-read** → write an in-flight claim → unlock;
+3. run the work **outside** the lock;
+4. record the result, or release the claim.
+
+The re-read inside the lock is what makes it correct: two callers that both missed the pre-lock
+read would otherwise both claim, and the second would overwrite the first.
+
+The obvious alternative — hold the lock for the whole execution and let the lock itself mean "in
+flight" — is wrong for reasons that survive the port from Go:
+
+- **A held lock is a held resource.** The postgres lock provider runs inside a transaction;
+  holding it for the duration of the work means an open transaction per in-flight request — pool
+  exhaustion, blocked vacuums, replication lag.
+- **Lock keys can collide.** Postgres advisory locks fold a key into an int64, so unrelated keys
+  can contend. Under a held lock a collision answers a legitimate request with a refusal; under a
+  short one it costs a sub-millisecond wait (`lockWaitMs`).
+- **Lock TTLs are shorter than real work.** Any work slower than the lease loses mutual exclusion
+  _while still running_ — precisely the failure this package exists to prevent.
+- **A lock leaves no evidence.** Kill a process mid-execution and the lock evaporates, so the
+  retry runs the work again. A _record_ with its own TTL survives, and the retry is correctly
+  refused until it expires.
+
+Every execution therefore writes twice — a claim, then an outcome — and the claim carries a claim
+id so that only its owner may complete or release it. That is what stops an execution which
+outlived its claim from overwriting whoever re-claimed the key.
+
+`withLock(lock, key, fn)` is exported for callers that want the acquire/run/release shape without
+the manager. `DistributedLock.acquire` reports contention immediately rather than blocking, so it
+retries for `waitMs` before reporting `{ acquired: false }`.
+
+## Choosing TTLs
+
+`inFlightTtlMs` is a **deadline for the work**, not a tuning knob. Set it above the worst case,
+not the average — every execution slower than it can produce a duplicate. Two minutes suits a
+request-shaped workload. It is also how long a client is refused after a process dies
+mid-execution; with the outcome unknown, refusing is the conservative answer.
+
+`ttlMs` is how long a client may usefully retry. A day is the common answer and matches what
+payment providers publish. Endpoints that disagree do not need a manager each: `run` takes a
+per-call `ttlMs`. There is deliberately no per-call `inFlightTtlMs` — it bounds how long a dead
+process blocks a retry, which is a property of the deployment rather than of the call.
+
+## Store failure policy
+
+The two answers fail in opposite directions, so the choice belongs to the caller.
+`fail-closed` (the default) refuses the request when the record store is unreachable: a brief
+outage becomes downtime rather than duplicate charges, which is the right answer wherever the
+guarded work costs money. `fail-open` runs the work anyway, trading the guarantee for
+availability.
+
+The policy covers **reads, claim writes, and lock failures** alike. (platform-go applies it to
+reads only, so a `FailOpen` manager still rejects when the claim write fails; that is a divergence
+this port makes deliberately — a policy that only holds for reads is not the promise its name
+makes.)
+
+## The locker matters
+
+The noop locker acquires unconditionally. With it, replay still works — which covers the ordinary
+timeout-then-retry case — but two genuinely concurrent requests can both claim and both execute.
+The `lock` dep is required and has no default so that nobody arrives there by accident.
+
+## Fingerprints
+
+A fingerprint identifies _what_ the operation was, so a key reused for a different request can be
+detected. `fingerprintRequest` covers method, path, **sorted** query, principal, and body; parts
+are length-prefixed so they cannot run together (`/a` + `bc` must not hash like `/ab` + `c`).
+
+`canonicalJson` is the canonicalisation: object keys sorted recursively, array order preserved,
+`toJSON` honoured, `NaN`/`Infinity` as `null`. It exists because a false mismatch is a _rejected
+legitimate retry_ — property order and re-serialisation must not change the answer.
+
+Keys and fingerprints are branded string types. `run` takes one of each, adjacently, and as bare
+strings a transposed pair would type-check and silently disable mismatch detection — a security
+control failing open with no signal. Convert at the wire boundary with `parseIdempotencyKey`
+(which also validates: printable, space-free ASCII, length-capped) and `asFingerprint`.
+
+## Watching it
+
+| Instrument                    | Watch it for                                                     |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `idempotency.claims.lost`     | **The alert.** Work outran `inFlightTtlMs`; the claim was taken  |
+| `idempotency.record.failures` | The effect happened, the record did not — a retry will re-run it |
+| `idempotency.requests`        | By `outcome`; the four sum to the request total                  |
+| `idempotency.store.errors`    | Store health                                                     |
+| `idempotency.stale.records`   | Records ignored for another version; one spike per shape change  |
+
+A steady stream of `in_flight` without matching `executed` usually means work is dying
+mid-execution. `mismatch` is always a client bug. End-to-end latency comes from observability's
+`operation.duration{operation="run"}`, so there is no second histogram here saying the same thing.
+
+## Record versioning
+
+Every record is stamped with `RECORD_VERSION`, and a record written by another version is
+**ignored rather than misread** — it reads as a miss and the work re-runs. With a day-long TTL,
+treating an unreadable record as an error would turn one bad deploy into a day of failures. Bump
+`RECORD_VERSION` when the stored shape changes.
+
+Keep `T` JSON-safe: the redis cache provider serialises with JSON, so `Date`/`Map`/`Set` do not
+survive the round trip as themselves.
+
+## The isomorphic split
+
+The split is **asymmetric**, which is the one place this package departs from the usual
+"identical factory on both sides" shape:
+
+- `index.browser.ts` — key minting, fingerprints, and the `fetch` wrapper.
+- `index.node.ts` — the same client half, plus `provideIdempotencyManager`.
+
+A browser has no record store and no distributed lock, so a manager there could only pretend, and
+a noop stand-in would be the worst possible shape: idempotency that looks wired up and guarantees
+nothing. Importing `provideIdempotencyManager` from browser-resolved code is therefore a type
+error, which is the intended feedback. The client half ships to the browser because that is where
+the retrying client lives — which is where "mint outside the retry loop" actually gets broken.
+
+## Not ported
+
+The transport adapters (`idempotency/http`, `idempotency/grpc`) — server middleware, response
+capture and replay, and the gRPC interceptors. This package knows nothing about HTTP beyond the
+header name and `fingerprintRequest`; wiring it into a router is currently the caller's job.

--- a/packages/idempotency/README.md
+++ b/packages/idempotency/README.md
@@ -97,7 +97,7 @@ switch (result.status) {
 The four outcomes are **returned, not thrown**: they are expected control flow, and the
 discriminated union fits this repo's optional-over-sentinels stance better than Go's error
 sentinels. Thrown `PlatformError`s (`idempotency/*` codes) are reserved for genuine failures — an
-unusable key, an empty fingerprint, an unreachable record store under `fail-closed`.
+unusable key, an empty fingerprint, an unreachable record store.
 
 ## The claim protocol
 
@@ -147,15 +147,21 @@ process blocks a retry, which is a property of the deployment rather than of the
 ## Store failure policy
 
 The two answers fail in opposite directions, so the choice belongs to the caller.
-`fail-closed` (the default) refuses the request when the record store is unreachable: a brief
-outage becomes downtime rather than duplicate charges, which is the right answer wherever the
-guarded work costs money. `fail-open` runs the work anyway, trading the guarantee for
-availability.
+`fail-closed` (the default) refuses the request when a record read fails: a brief outage becomes
+downtime rather than duplicate charges, which is the right answer wherever the guarded work costs
+money. `fail-open` treats the failed read as a miss and runs the work anyway, trading the
+guarantee for availability.
 
-The policy covers **reads, claim writes, and lock failures** alike. (platform-go applies it to
-reads only, so a `FailOpen` manager still rejects when the claim write fails; that is a divergence
-this port makes deliberately — a policy that only holds for reads is not the promise its name
-makes.)
+**The policy governs reads only**, matching platform-go. A read can fail open because "no record"
+is a coherent — if unprotected — answer to carry on from. A claim that could not be _written_
+leaves the completion nothing to prove ownership against, so a failed claim write, or an
+unreachable locker, refuses the request under either policy.
+
+The practical consequence is worth stating plainly: a store that is _wholly_ unreachable refuses
+the request even under `fail-open`, because the claim write cannot land either. What `fail-open`
+buys is tolerance of a failing **read** path — and in that case the completion write is also
+skipped (the claim cannot be confirmed as ours), so the execution counts against
+`idempotency.claims.lost` and a later retry will re-run the work.
 
 ## The locker matters
 

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@primandproper/idempotency",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Isomorphic idempotency: client key minting plus a server-side manager that runs work at most once per key.",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/primandproper/platform-ts.git",
+    "directory": "packages/idempotency"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      },
+      "default": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      }
+    }
+  },
+  "types": "./dist/index.node.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@primandproper/cache": "workspace:*",
+    "@primandproper/cryptography": "workspace:*",
+    "@primandproper/distributedlock": "workspace:*",
+    "@primandproper/errors": "workspace:*",
+    "@primandproper/identifiers": "workspace:*",
+    "@primandproper/observability": "workspace:*",
+    "zod": "3.25.76"
+  }
+}

--- a/packages/idempotency/src/client.test.ts
+++ b/packages/idempotency/src/client.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { idempotentFetch } from "./client.js";
+import { IDEMPOTENCY_KEY_HEADER, parseIdempotencyKey } from "./key.js";
+
+/** Captures what the wrapper would have sent, without a network. */
+function recordingFetch(): {
+  fetch: typeof fetch;
+  calls: { input: RequestInfo | URL; init: RequestInit | undefined }[];
+} {
+  const calls: { input: RequestInfo | URL; init: RequestInit | undefined }[] = [];
+  return {
+    calls,
+    fetch: (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      calls.push({ input, init });
+      return Promise.resolve(new Response(null, { status: 204 }));
+    },
+  };
+}
+
+/** The key the wrapper actually put on the wire for call `index`. */
+function sentKey(init: RequestInit | undefined): string | null {
+  return new Headers(init?.headers).get(IDEMPOTENCY_KEY_HEADER);
+}
+
+describe("idempotentFetch", () => {
+  it("stamps the key it minted", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    await send("/charges", { method: "POST" });
+
+    expect(sentKey(spy.calls[0]?.init)).toBe(send.key);
+  });
+
+  it("sends the same key on every attempt — the whole point of binding it to the wrapper", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    // Standing in for a retry loop: the wrapper is built once, outside it.
+    await send("/charges", { method: "POST", body: "{}" });
+    await send("/charges", { method: "POST", body: "{}" });
+
+    expect(sentKey(spy.calls[0]?.init)).toBe(sentKey(spy.calls[1]?.init));
+  });
+
+  it("leaves safe methods alone", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    await send("/charges");
+    await send("/charges", { method: "GET" });
+
+    expect(sentKey(spy.calls[0]?.init)).toBeNull();
+    expect(sentKey(spy.calls[1]?.init)).toBeNull();
+  });
+
+  it("never overrides a key the caller set itself", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    await send("/charges", {
+      method: "POST",
+      headers: { [IDEMPOTENCY_KEY_HEADER]: "caller-owned" },
+    });
+
+    expect(sentKey(spy.calls[0]?.init)).toBe("caller-owned");
+  });
+
+  it("reuses a supplied key instead of minting one", () => {
+    const key = parseIdempotencyKey("resumed-operation");
+    expect(idempotentFetch({ key }).key).toBe(key);
+  });
+
+  it("does not mutate the init the caller passed", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+    // The shape a retry loop produces: one init object reused for every attempt.
+    const init: RequestInit = {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+    };
+
+    await send("/charges", init);
+
+    expect(new Headers(init.headers).has(IDEMPOTENCY_KEY_HEADER)).toBe(false);
+    expect(sentKey(spy.calls[0]?.init)).toBe(send.key);
+    expect(new Headers(spy.calls[0]?.init?.headers).get("content-type")).toBe(
+      "text/plain",
+    );
+  });
+
+  it("keeps a Request's own headers when no init headers are given", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    await send(
+      new Request("https://api.example.com/charges", {
+        method: "POST",
+        headers: { "x-trace": "abc" },
+      }),
+    );
+
+    expect(new Headers(spy.calls[0]?.init?.headers).get("x-trace")).toBe("abc");
+    expect(sentKey(spy.calls[0]?.init)).toBe(send.key);
+  });
+
+  it("honours a Request's own already-set key", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({ fetch: spy.fetch });
+
+    await send(
+      new Request("https://api.example.com/charges", {
+        method: "POST",
+        headers: { [IDEMPOTENCY_KEY_HEADER]: "caller-owned" },
+      }),
+    );
+
+    expect(spy.calls[0]?.init).toBeUndefined();
+  });
+
+  it("takes a custom header name and method set", async () => {
+    const spy = recordingFetch();
+    const send = idempotentFetch({
+      fetch: spy.fetch,
+      headerName: "X-Idempotency",
+      methods: ["GET"],
+    });
+
+    await send("/charges");
+    await send("/charges", { method: "POST" });
+
+    expect(new Headers(spy.calls[0]?.init?.headers).get("X-Idempotency")).toBe(send.key);
+    expect(spy.calls[1]?.init?.headers).toBeUndefined();
+  });
+});

--- a/packages/idempotency/src/client.ts
+++ b/packages/idempotency/src/client.ts
@@ -1,0 +1,114 @@
+import {
+  IDEMPOTENCY_KEY_HEADER,
+  newIdempotencyKey,
+  type IdempotencyKey,
+  type KeyDeps,
+} from "./key.js";
+
+/**
+ * The methods that participate by default. Safe methods are excluded even when a key is
+ * present: they have no effect to deduplicate, and recording them would spend the store on
+ * nothing.
+ */
+export const IDEMPOTENT_METHODS: readonly string[] = ["POST", "PUT", "PATCH", "DELETE"];
+
+/** Options for {@link idempotentFetch}. */
+export interface IdempotentFetchOptions extends KeyDeps {
+  /** The `fetch` to delegate to. Defaults to the global. */
+  fetch?: typeof fetch;
+  /**
+   * Reuse an existing key instead of minting one — for a caller that already has the key
+   * (rehydrating a resumed operation, say, or one it logged before the first attempt).
+   */
+  key?: IdempotencyKey;
+  /** Overrides the header the key is sent in. */
+  headerName?: string;
+  /** Overrides which methods carry the key. */
+  methods?: readonly string[];
+}
+
+/** A `fetch` that stamps one operation's idempotency key on every request it sends. */
+export interface IdempotentFetch {
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  /** The key this wrapper stamps. Log it: it is what a support request is traced by. */
+  readonly key: IdempotencyKey;
+  /** The header the key is sent in. */
+  readonly headerName: string;
+}
+
+/** Guards the `Request` global, which an exotic host may not define even where `fetch` exists. */
+function isRequest(input: RequestInfo | URL): input is Request {
+  return typeof Request !== "undefined" && input instanceof Request;
+}
+
+/** Reads the method an about-to-be-sent request will use, defaulting as `fetch` does. */
+function methodOf(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method !== undefined) {
+    return init.method.toUpperCase();
+  }
+  return isRequest(input) ? input.method.toUpperCase() : "GET";
+}
+
+/**
+ * The headers the request would be sent with, unchanged. `fetch(request, init)` takes headers
+ * from `init` *instead of* the request's when `init.headers` is present rather than merging
+ * them, so stamping onto a merge of the two would resurrect headers the caller meant to drop.
+ */
+function effectiveHeaders(input: RequestInfo | URL, init?: RequestInit): Headers {
+  if (init?.headers !== undefined) {
+    return new Headers(init.headers);
+  }
+  return new Headers(isRequest(input) ? input.headers : undefined);
+}
+
+/**
+ * Binds one freshly minted idempotency key to a `fetch` wrapper, so every request it sends
+ * carries that same key.
+ *
+ * **The wrapper is the key**, and that is the whole point of this shape. Build it once per
+ * logical operation, outside the retry loop:
+ *
+ * ```ts
+ * const send = idempotentFetch();                // mints once, OUTSIDE the loop
+ * await policy.run(() => send("/charges", { method: "POST", body }));
+ * ```
+ *
+ * Building it *inside* the loop mints a key per attempt — which looks like protection and
+ * provides none, since a retry and a deliberate duplicate are byte-identical to the server. The
+ * mistake is at least visible here, because the construction is what moved.
+ *
+ * There is deliberately no "mint a key per call" mode. A wrapper cannot tell a retry from a
+ * second, intentional request, so inventing a key per call would offer nothing, and deriving one
+ * from the request's content would fail the other way — deciding two intentional identical
+ * charges are the same one and silently dropping the second. Only the caller knows where a
+ * logical operation begins.
+ *
+ * An already-set header always wins, and safe methods are left alone.
+ */
+export function idempotentFetch(options: IdempotentFetchOptions = {}): IdempotentFetch {
+  const headerName = options.headerName ?? IDEMPOTENCY_KEY_HEADER;
+  const methods = options.methods ?? IDEMPOTENT_METHODS;
+  const key =
+    options.key ??
+    newIdempotencyKey(
+      options.generate !== undefined ? { generate: options.generate } : {},
+    );
+  const delegate =
+    options.fetch ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+
+  const send = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const headers = effectiveHeaders(input, init);
+    // An already-set key means the caller is managing keys itself; never override it.
+    if (!methods.includes(methodOf(input, init)) || headers.has(headerName)) {
+      return delegate(input, init);
+    }
+
+    // The header goes on a copy of `init` rather than being mutated in place: a caller that
+    // builds one `init` outside its retry loop and passes it to every attempt must not have that
+    // object rewritten underneath it.
+    headers.set(headerName, key);
+    return delegate(input, { ...init, headers });
+  };
+
+  return Object.assign(send, { key, headerName });
+}

--- a/packages/idempotency/src/config.test.ts
+++ b/packages/idempotency/src/config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { IdempotencyConfigSchema } from "./config.js";
+
+describe("IdempotencyConfigSchema", () => {
+  it("defaults to a day of retention, a two-minute claim, and failing closed", () => {
+    expect(IdempotencyConfigSchema.parse({})).toEqual({
+      keyPrefix: "idempotency:",
+      ttlMs: 86_400_000,
+      inFlightTtlMs: 120_000,
+      maxKeyLength: 255,
+      storeFailurePolicy: "fail-closed",
+      lockTtlMs: 5_000,
+      lockWaitMs: 2_000,
+      lockPollMs: 25,
+    });
+  });
+
+  it("honours an empty key prefix rather than treating it as unset", () => {
+    // Opting out of namespacing is a legitimate choice — e.g. a store used for nothing else.
+    expect(IdempotencyConfigSchema.parse({ keyPrefix: "" }).keyPrefix).toBe("");
+  });
+
+  it("rejects a non-positive TTL", () => {
+    expect(() => IdempotencyConfigSchema.parse({ ttlMs: 0 })).toThrow();
+    expect(() => IdempotencyConfigSchema.parse({ inFlightTtlMs: -1 })).toThrow();
+  });
+
+  it("allows a zero key-length cap (disabling the check) and a zero lock wait", () => {
+    expect(IdempotencyConfigSchema.parse({ maxKeyLength: 0 }).maxKeyLength).toBe(0);
+    expect(IdempotencyConfigSchema.parse({ lockWaitMs: 0 }).lockWaitMs).toBe(0);
+  });
+
+  it("rejects an unknown store failure policy", () => {
+    expect(() =>
+      IdempotencyConfigSchema.parse({ storeFailurePolicy: "maybe" }),
+    ).toThrow();
+  });
+});

--- a/packages/idempotency/src/config.ts
+++ b/packages/idempotency/src/config.ts
@@ -41,13 +41,19 @@ export const IdempotencyConfigSchema = z.object({
   /** The longest client key accepted. `0` disables the length check. */
   maxKeyLength: z.number().int().nonnegative().default(DEFAULT_MAX_KEY_LENGTH),
   /**
-   * What happens when the record store cannot be reached. The most consequential setting here,
-   * because the two answers fail in opposite directions.
+   * What happens when a record **read** fails. The most consequential setting here, because the
+   * two answers fail in opposite directions.
    *
    * `fail-closed` (the default) refuses the request: a brief outage becomes downtime rather than
    * duplicate charges, and it is the right answer wherever the guarded work costs money.
-   * `fail-open` runs the work anyway, trading the guarantee for availability — appropriate only
-   * where a duplicate effect is cheaper than a rejection.
+   * `fail-open` treats the failed read as a miss and runs the work anyway, trading the guarantee
+   * for availability — appropriate only where a duplicate effect is cheaper than a rejection.
+   *
+   * It governs reads only, matching platform-go. A claim that could not be *written* leaves the
+   * completion nothing to prove ownership against, so a failed claim write (or an unreachable
+   * locker) refuses the request under either policy. In practice that means a store which is
+   * wholly unreachable refuses the request even under `fail-open`; what `fail-open` buys is
+   * tolerance of a failing read path.
    */
   storeFailurePolicy: z.enum(["fail-closed", "fail-open"]).default("fail-closed"),
   /**

--- a/packages/idempotency/src/config.ts
+++ b/packages/idempotency/src/config.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { DEFAULT_MAX_KEY_LENGTH } from "./key.js";
+
+/** One day, in milliseconds — how long a completed record stays replayable by default. */
+const DEFAULT_TTL_MS = 86_400_000;
+
+/** Two minutes, in milliseconds — the default deadline for the work a claim guards. */
+const DEFAULT_IN_FLIGHT_TTL_MS = 120_000;
+
+/**
+ * Idempotency config. Replaces the Go platform's `env:`-tagged struct + ozzo validation.
+ *
+ * The record store and the locker are **not** configured here: both are runtime values built by
+ * their own packages' factories and passed through deps, which is how the rest of this repo
+ * composes (no DI container).
+ */
+export const IdempotencyConfigSchema = z.object({
+  /**
+   * Namespaces store and lock keys, so a client's key cannot collide with an unrelated entry in
+   * a cache or locker shared with something else. An empty prefix is honoured — opting out is a
+   * legitimate choice.
+   */
+  keyPrefix: z.string().default("idempotency:"),
+  /**
+   * How long a completed record stays replayable, in milliseconds. This is how long a client may
+   * usefully retry; a day is the common answer and matches what payment providers publish.
+   * Longer costs storage, shorter means a late retry re-executes.
+   */
+  ttlMs: z.number().int().positive().default(DEFAULT_TTL_MS),
+  /**
+   * How long a claim survives without being completed, in milliseconds.
+   *
+   * A deadline for the guarded work, not a tuning knob: set it above the worst case, not the
+   * average. Every execution slower than this loses its claim *while still running*, which is
+   * the one remaining path to a duplicate effect — watch `idempotency.claims.lost`. It is also
+   * how long a client is refused after a process dies mid-execution, which is the best available
+   * answer when the outcome is unknown.
+   */
+  inFlightTtlMs: z.number().int().positive().default(DEFAULT_IN_FLIGHT_TTL_MS),
+  /** The longest client key accepted. `0` disables the length check. */
+  maxKeyLength: z.number().int().nonnegative().default(DEFAULT_MAX_KEY_LENGTH),
+  /**
+   * What happens when the record store cannot be reached. The most consequential setting here,
+   * because the two answers fail in opposite directions.
+   *
+   * `fail-closed` (the default) refuses the request: a brief outage becomes downtime rather than
+   * duplicate charges, and it is the right answer wherever the guarded work costs money.
+   * `fail-open` runs the work anyway, trading the guarantee for availability — appropriate only
+   * where a duplicate effect is cheaper than a rejection.
+   */
+  storeFailurePolicy: z.enum(["fail-closed", "fail-open"]).default("fail-closed"),
+  /**
+   * Lease held while claiming, in milliseconds. Short by design: the lock covers a re-read and a
+   * write, never the work itself.
+   */
+  lockTtlMs: z.number().int().positive().default(5_000),
+  /**
+   * How long to keep retrying a contended claim lock before giving up and answering `in-flight`,
+   * in milliseconds. `0` means a single attempt.
+   *
+   * A wait exists because `DistributedLock.acquire` reports contention immediately rather than
+   * blocking, and because lock keys can collide: the postgres provider folds a key into an
+   * int64, so an unrelated key can contend. Under a short wait that collision costs a
+   * sub-millisecond pause; without one it would answer a legitimate request with a refusal.
+   */
+  lockWaitMs: z.number().int().nonnegative().default(2_000),
+  /** How long to wait between attempts on a contended claim lock, in milliseconds. */
+  lockPollMs: z.number().int().positive().default(25),
+});
+
+export type IdempotencyConfig = z.infer<typeof IdempotencyConfigSchema>;
+export type IdempotencyConfigInput = z.input<typeof IdempotencyConfigSchema>;
+
+/** The store-failure policies, spelled out for callers switching on them. */
+export type StoreFailurePolicy = IdempotencyConfig["storeFailurePolicy"];

--- a/packages/idempotency/src/fingerprint.test.ts
+++ b/packages/idempotency/src/fingerprint.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalJson,
+  fingerprintJson,
+  fingerprintOf,
+  fingerprintRequest,
+} from "./fingerprint.js";
+
+describe("canonicalJson", () => {
+  it("sorts object keys recursively, so property order is not a false mismatch", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe(
+      canonicalJson({ a: { c: 3, d: 2 }, b: 1 }),
+    );
+  });
+
+  it("keeps array order, because order is meaning in an array", () => {
+    expect(canonicalJson([1, 2])).not.toBe(canonicalJson([2, 1]));
+  });
+
+  it("normalises numbers the way JSON does, so a re-serialised payload still matches", () => {
+    expect(canonicalJson({ n: 1.0 })).toBe(canonicalJson({ n: 1 }));
+    expect(canonicalJson({ n: Number.NaN })).toBe('{"n":null}');
+  });
+
+  it("honours toJSON, so a Date canonicalises to its ISO string", () => {
+    expect(canonicalJson({ at: new Date(0) })).toBe('{"at":"1970-01-01T00:00:00.000Z"}');
+  });
+
+  it("drops undefined from objects and nulls it in arrays, as JSON.stringify does", () => {
+    expect(canonicalJson({ a: undefined, b: 1 })).toBe('{"b":1}');
+    expect(canonicalJson([undefined])).toBe("[null]");
+  });
+
+  it("renders a bare undefined as null rather than returning undefined", () => {
+    expect(canonicalJson(undefined)).toBe("null");
+  });
+});
+
+describe("fingerprintOf", () => {
+  it("is stable for the same parts", async () => {
+    await expect(fingerprintOf(["a", "b"])).resolves.toBe(
+      await fingerprintOf(["a", "b"]),
+    );
+  });
+
+  it("length-prefixes parts, so a shifted boundary is a different fingerprint", async () => {
+    // Without framing, "a" + "bc" and "ab" + "c" would hash identically — and one user's
+    // recorded response could be replayed to another.
+    expect(await fingerprintOf(["a", "bc"])).not.toBe(await fingerprintOf(["ab", "c"]));
+  });
+
+  it("accepts raw bytes alongside strings", async () => {
+    const digest = await fingerprintOf(["POST", new Uint8Array([1, 2, 3])]);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("fingerprintJson", () => {
+  it("treats reordered keys as the same request", async () => {
+    expect(await fingerprintJson({ a: 1, b: 2 })).toBe(
+      await fingerprintJson({ b: 2, a: 1 }),
+    );
+  });
+
+  it("treats a different value as a different request", async () => {
+    expect(await fingerprintJson({ amount: 100 })).not.toBe(
+      await fingerprintJson({ amount: 101 }),
+    );
+  });
+});
+
+describe("fingerprintRequest", () => {
+  const base = { method: "POST", url: "/charges", principal: "user-1", body: "{}" };
+
+  it("is stable across attempts of the same request", async () => {
+    expect(await fingerprintRequest(base)).toBe(await fingerprintRequest(base));
+  });
+
+  it("sorts the query, so parameter order is not reported as key reuse", async () => {
+    expect(await fingerprintRequest({ ...base, url: "/charges?a=1&b=2" })).toBe(
+      await fingerprintRequest({ ...base, url: "/charges?b=2&a=1" }),
+    );
+  });
+
+  it("commits to the method, path, query, principal, and body", async () => {
+    const original = await fingerprintRequest(base);
+    expect(await fingerprintRequest({ ...base, method: "PUT" })).not.toBe(original);
+    expect(await fingerprintRequest({ ...base, url: "/refunds" })).not.toBe(original);
+    expect(await fingerprintRequest({ ...base, url: "/charges?a=1" })).not.toBe(original);
+    expect(await fingerprintRequest({ ...base, principal: "user-2" })).not.toBe(original);
+    expect(await fingerprintRequest({ ...base, body: '{"a":1}' })).not.toBe(original);
+  });
+
+  it("ignores the origin, so the same request through two hosts matches", async () => {
+    expect(
+      await fingerprintRequest({ ...base, url: "https://api.example.com/charges" }),
+    ).toBe(await fingerprintRequest(base));
+  });
+
+  it("case-folds the method", async () => {
+    expect(await fingerprintRequest({ ...base, method: "post" })).toBe(
+      await fingerprintRequest(base),
+    );
+  });
+});

--- a/packages/idempotency/src/fingerprint.ts
+++ b/packages/idempotency/src/fingerprint.ts
@@ -1,0 +1,147 @@
+import { provideHashing, type Hasher } from "@primandproper/cryptography";
+
+import { asFingerprint, type Fingerprint } from "./key.js";
+
+/** Injectable digest, so a caller can pin the algorithm or a test can pin the output. */
+export interface FingerprintDeps {
+  /** Defaults to SHA-256 over WebCrypto, identical on Node and in the browser. */
+  hasher?: Hasher;
+}
+
+const encoder = new TextEncoder();
+
+const defaultHasher = provideHashing({ algorithm: "SHA-256" });
+
+/** Renders a digest as lowercase hex — the wire form a fingerprint travels and is stored in. */
+function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/**
+ * Hashes an ordered list of parts into a fingerprint.
+ *
+ * Each part is **length-prefixed** so that parts cannot run together: without it a path of `/a`
+ * with principal `bc` and a path of `/ab` with principal `c` would hash identically, and one
+ * user's recorded response could be replayed to another.
+ */
+export async function fingerprintOf(
+  parts: readonly (string | Uint8Array)[],
+  deps: FingerprintDeps = {},
+): Promise<Fingerprint> {
+  const hasher = deps.hasher ?? defaultHasher;
+  const framed: Uint8Array[] = [];
+  let length = 0;
+  for (const part of parts) {
+    const bytes = typeof part === "string" ? encoder.encode(part) : part;
+    const prefix = encoder.encode(`${String(bytes.byteLength)}:`);
+    framed.push(prefix, bytes);
+    length += prefix.byteLength + bytes.byteLength;
+  }
+
+  const buffer = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of framed) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return asFingerprint(toHex(await hasher.hash(buffer)));
+}
+
+/**
+ * Serialises a value to JSON with object keys sorted, recursively — the canonicalisation a
+ * fingerprint over structured data needs.
+ *
+ * Two things would otherwise produce false mismatches, and a false mismatch is a *rejected
+ * legitimate retry*: property order (`{a,b}` and `{b,a}` are the same request), and a client
+ * that re-serialises its payload between attempts. Sorting fixes the first. The second is why
+ * fingerprinting structured data is preferred over hashing raw bytes wherever the caller has
+ * the parsed value to hand.
+ *
+ * What it commits to: keys sort by UTF-16 code unit; arrays keep their order (order is meaning
+ * in an array); `undefined`, functions, and symbols drop out of objects and become `null` in
+ * arrays, exactly as `JSON.stringify` does; `toJSON` is honoured, so a `Date` canonicalises to
+ * its ISO string; `NaN`/`Infinity` become `null`. Number formatting is deterministic — the
+ * ECMAScript spec pins `Number`-to-`String` — so `1.0` and `1` canonicalise identically, which
+ * is the answer that treats a re-serialised payload as the same request.
+ */
+export function canonicalJson(value: unknown): string {
+  // Handled up front because `JSON.stringify` returns `undefined` (not a string) for these,
+  // which its lib type does not admit — and a fingerprint must always be a string.
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    return "null";
+  }
+
+  return JSON.stringify(value, (_key, entry: unknown) => {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+      return entry;
+    }
+    // The replacer runs after `toJSON`, so anything reaching here is a plain-ish object whose
+    // own enumerable keys are what get serialised — reordering them here reorders the output.
+    return Object.fromEntries(
+      Object.entries(entry as Record<string, unknown>).sort(([a], [b]) =>
+        a < b ? -1 : a > b ? 1 : 0,
+      ),
+    );
+  });
+}
+
+/** Fingerprints a structured value through {@link canonicalJson}. */
+export function fingerprintJson(
+  value: unknown,
+  deps: FingerprintDeps = {},
+): Promise<Fingerprint> {
+  return fingerprintOf([canonicalJson(value)], deps);
+}
+
+/** The parts of an HTTP request a fingerprint commits to. */
+export interface RequestFingerprintInput {
+  method: string;
+  /** Absolute or relative; only the path and query participate. */
+  url: string | URL;
+  /**
+   * Who is making the request. Include it: a fingerprint over the request alone would let the
+   * same payload sent by two different users share one record, handing the second caller the
+   * first's response.
+   */
+  principal?: string;
+  /** The raw body, or a structured value to canonicalise via {@link canonicalJson}. */
+  body?: string | Uint8Array;
+}
+
+/**
+ * Fingerprints an HTTP request over method, path, sorted query, principal, and body.
+ *
+ * It covers more than the body on purpose — a key committed only to a body would let the same
+ * payload posted to two endpoints share one record. The query is sorted rather than taken
+ * verbatim, because `?a=1&b=2` and `?b=2&a=1` are the same request and reporting an ordinary
+ * retry as key reuse is the expensive direction to be wrong in.
+ */
+export function fingerprintRequest(
+  input: RequestFingerprintInput,
+  deps: FingerprintDeps = {},
+): Promise<Fingerprint> {
+  // A base is supplied so a relative URL parses; only path and query are read back out, so the
+  // placeholder origin never reaches the digest.
+  const url =
+    typeof input.url === "string"
+      ? new URL(input.url, "http://fingerprint.invalid")
+      : input.url;
+  const query = new URLSearchParams(url.search);
+  query.sort();
+
+  return fingerprintOf(
+    [
+      input.method.toUpperCase(),
+      url.pathname,
+      query.toString(),
+      input.principal ?? "",
+      input.body ?? "",
+    ],
+    deps,
+  );
+}

--- a/packages/idempotency/src/index.browser.ts
+++ b/packages/idempotency/src/index.browser.ts
@@ -1,0 +1,16 @@
+/**
+ * Browser entry: the client half only — minting a key, fingerprinting a request, and the `fetch`
+ * wrapper that keeps one key stable across retries.
+ *
+ * The server-side manager is absent rather than stubbed. It needs a record store and a
+ * distributed lock, neither of which exists in a browser, and a noop stand-in would be the worst
+ * possible shape: idempotency that looks wired up and guarantees nothing. Importing
+ * `provideIdempotencyManager` in browser-resolved code is therefore a type error, which is the
+ * intended feedback.
+ *
+ * Splitting the package this way is what makes the "mint outside the retry loop" rule
+ * enforceable in the place it actually gets broken — the retrying client.
+ */
+export * from "./client.js";
+export * from "./fingerprint.js";
+export * from "./key.js";

--- a/packages/idempotency/src/index.node.ts
+++ b/packages/idempotency/src/index.node.ts
@@ -1,0 +1,16 @@
+/**
+ * Node entry: the client half (key minting, fingerprints, the `fetch` wrapper) plus the
+ * server-side {@link IdempotencyManager} the browser entry deliberately does not carry.
+ *
+ * The asymmetry is the point of the split — see the package README. A browser has no record
+ * store and no distributed lock, so a manager there could only pretend; a server, meanwhile,
+ * needs the client half too, since it is a client of other services.
+ */
+export * from "./client.js";
+export * from "./config.js";
+export * from "./fingerprint.js";
+export * from "./instruments.js";
+export * from "./key.js";
+export * from "./record.js";
+export * from "./manager.node.js";
+export * from "./with-lock.node.js";

--- a/packages/idempotency/src/instruments.ts
+++ b/packages/idempotency/src/instruments.ts
@@ -1,0 +1,60 @@
+import {
+  makeMetrics,
+  type Metrics,
+  type ObservabilityDeps,
+} from "@primandproper/observability";
+
+type Counter = ReturnType<Metrics["counter"]>;
+
+/**
+ * What a manager reports. Idempotency is a control that fails silently when it fails at all, so
+ * the instruments are the only way to learn it has stopped working.
+ *
+ * `claimsLost` is the one to alert on: it is the only remaining path to a duplicate effect, and
+ * it always means the same thing — `inFlightTtlMs` is too short for the work it guards.
+ *
+ * There is no latency instrument here on purpose: `Observer.run` already records
+ * `operation.duration{operation="run"}` for every call, and a second histogram over the same
+ * span would be the same number under two names.
+ */
+export interface IdempotencyInstruments {
+  /** Every resolved call, tagged `outcome` (`executed`/`replayed`/`in_flight`/`mismatch`). */
+  requests: Counter;
+  /** Work outran its claim and the key was taken by someone else. The alert. */
+  claimsLost: Counter;
+  /** The effect happened, the record did not land, and a retry will run the work again. */
+  recordFailures: Counter;
+  /** Store health: a read or write the record store refused. */
+  storeErrors: Counter;
+  /** Records ignored for carrying another version — expect one spike after a shape change. */
+  staleRecords: Counter;
+}
+
+/** Builds the manager's instruments, defaulting to the noop meter. */
+export function idempotencyInstruments(
+  o11yName: string,
+  deps: ObservabilityDeps | undefined,
+): IdempotencyInstruments {
+  const metrics = makeMetrics(o11yName, deps?.metrics);
+  return {
+    requests: metrics.counter("idempotency.requests", {
+      description:
+        "Count of resolved idempotent calls, tagged by outcome (executed/replayed/in_flight/mismatch).",
+    }),
+    claimsLost: metrics.counter("idempotency.claims.lost", {
+      description:
+        "Count of executions whose claim was taken by someone else before they could complete it.",
+    }),
+    recordFailures: metrics.counter("idempotency.record.failures", {
+      description:
+        "Count of completed executions whose result could not be recorded, so a retry will re-run the work.",
+    }),
+    storeErrors: metrics.counter("idempotency.store.errors", {
+      description: "Count of record-store reads or writes that failed.",
+    }),
+    staleRecords: metrics.counter("idempotency.stale.records", {
+      description:
+        "Count of stored records ignored for carrying a different record version.",
+    }),
+  };
+}

--- a/packages/idempotency/src/key.test.ts
+++ b/packages/idempotency/src/key.test.ts
@@ -1,0 +1,92 @@
+import { isPlatformError } from "@primandproper/errors";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_KEY_LENGTH,
+  IdempotencyErrorCode,
+  newIdempotencyKey,
+  parseIdempotencyKey,
+  validateIdempotencyKey,
+} from "./key.js";
+
+/** Asserts `fn` throws a PlatformError carrying `code`. */
+function expectCode(fn: () => unknown, code: string): void {
+  try {
+    fn();
+  } catch (err) {
+    expect(isPlatformError(err, code)).toBe(true);
+    return;
+  }
+  expect.unreachable(`expected a ${code} error`);
+}
+
+describe("newIdempotencyKey", () => {
+  it("mints a usable key", () => {
+    const key = newIdempotencyKey();
+    expect(key).not.toBe("");
+    expect(() => {
+      validateIdempotencyKey(key);
+    }).not.toThrow();
+  });
+
+  it("mints a distinct key per call — which is why it belongs outside the retry loop", () => {
+    expect(newIdempotencyKey()).not.toBe(newIdempotencyKey());
+  });
+
+  it("takes an injectable generator", () => {
+    expect(newIdempotencyKey({ generate: () => "pinned" })).toBe("pinned");
+  });
+});
+
+describe("validateIdempotencyKey", () => {
+  it("accepts the shapes third-party clients actually send", () => {
+    for (const key of [
+      "3f0b1d5e-7c1a-4a5e-9d1e-2b3c4d5e6f70",
+      "cv0j2q9c00000356m1abcdefg",
+      "abc-_.~123",
+    ]) {
+      expect(() => {
+        validateIdempotencyKey(key);
+      }).not.toThrow();
+    }
+  });
+
+  it("rejects an empty key", () => {
+    expectCode(() => {
+      validateIdempotencyKey("");
+    }, IdempotencyErrorCode.keyRequired);
+  });
+
+  it("rejects a key past the maximum length", () => {
+    expectCode(() => {
+      validateIdempotencyKey("a".repeat(DEFAULT_MAX_KEY_LENGTH + 1));
+    }, IdempotencyErrorCode.keyTooLong);
+  });
+
+  it("honours a custom maximum, and a non-positive one disables the check", () => {
+    expectCode(() => {
+      validateIdempotencyKey("abcd", 3);
+    }, IdempotencyErrorCode.keyTooLong);
+    expect(() => {
+      validateIdempotencyKey("a".repeat(10_000), 0);
+    }).not.toThrow();
+  });
+
+  it("rejects characters that travel badly in a header or a store key", () => {
+    for (const key of ["with space", "tab\there", "newline\n", "nul\0", "emoji🙂", "é"]) {
+      expectCode(() => {
+        validateIdempotencyKey(key);
+      }, IdempotencyErrorCode.keyInvalid);
+    }
+  });
+});
+
+describe("parseIdempotencyKey", () => {
+  it("returns the branded key when valid", () => {
+    expect(parseIdempotencyKey("abc123")).toBe("abc123");
+  });
+
+  it("throws on an unusable key rather than branding it", () => {
+    expectCode(() => parseIdempotencyKey("bad key"), IdempotencyErrorCode.keyInvalid);
+  });
+});

--- a/packages/idempotency/src/key.ts
+++ b/packages/idempotency/src/key.ts
@@ -1,0 +1,125 @@
+import { PlatformError } from "@primandproper/errors";
+import { provideIdentifierGenerator } from "@primandproper/identifiers";
+
+/**
+ * A client-minted identifier for a *logical operation*, so a retry of it can be recognised as
+ * the same operation rather than as a new one.
+ *
+ * Branded rather than a bare `string` alias. {@link IdempotencyManager.run} takes a key and a
+ * {@link Fingerprint} adjacently and both are strings underneath: as aliases a transposed pair
+ * type-checks, runs, and silently disables mismatch detection — every request would
+ * fingerprint-match itself, so one key reused for two different requests would replay the first
+ * answer instead of being reported. A security control failing open with no signal is worth one
+ * conversion at the wire boundary ({@link parseIdempotencyKey}).
+ */
+export type IdempotencyKey = string & { readonly __brand: "idempotency-key" };
+
+/**
+ * Identifies *what* the operation was, so a key reused for a different request can be detected.
+ * Branded for the same reason as {@link IdempotencyKey}; build one with the helpers in
+ * `fingerprint.ts` rather than casting.
+ */
+export type Fingerprint = string & { readonly __brand: "idempotency-fingerprint" };
+
+/** The request header both halves of this package agree on, matching what Stripe publishes. */
+export const IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+/** The longest key accepted by default, matching the limit Stripe publishes for the same header. */
+export const DEFAULT_MAX_KEY_LENGTH = 255;
+
+/** Error codes thrown by this package. Namespaced per the `errors` package's open-code stance. */
+export const IdempotencyErrorCode = {
+  /** An empty key was supplied. */
+  keyRequired: "idempotency/key-required",
+  /** The key is longer than the configured maximum. */
+  keyTooLong: "idempotency/key-too-long",
+  /** The key contains bytes outside printable, space-free ASCII. */
+  keyInvalid: "idempotency/key-invalid",
+  /** `run` was called without a fingerprint, which would disable mismatch detection entirely. */
+  fingerprintRequired: "idempotency/fingerprint-required",
+  /** The record store could not be reached and the manager is configured to fail closed. */
+  storeUnavailable: "idempotency/store-unavailable",
+} as const;
+
+/** Injectable key generation, so a test can pin the minted value. */
+export interface KeyDeps {
+  /** Produces the raw string a fresh key is built from. Defaults to a nanoid. */
+  generate?: () => string;
+}
+
+const defaultGenerator = provideIdentifierGenerator();
+
+/**
+ * Mints a fresh key.
+ *
+ * Call it **once per logical operation, outside any retry loop**. That placement is the whole
+ * contract: every attempt must send the same key, which is what lets the server recognise a
+ * retry. A key minted inside the loop is a new key per attempt — it looks like protection and
+ * provides none, and nothing on the server can detect the mistake, because a retry and a
+ * deliberate duplicate are byte-identical.
+ *
+ * There is deliberately no round trip to acquire a key: a request that times out never returns
+ * anything, which is precisely the case this package exists for.
+ */
+export function newIdempotencyKey(deps: KeyDeps = {}): IdempotencyKey {
+  const generate = deps.generate ?? (() => defaultGenerator.generate());
+  return generate() as IdempotencyKey;
+}
+
+/**
+ * Validates a client-supplied key, throwing a {@link PlatformError} when it is unusable.
+ *
+ * A key becomes both a store key and a lock key, so it is restricted rather than escaped:
+ * printable ASCII with no spaces, which admits the UUIDs, nanoids, and base64url tokens clients
+ * actually send while excluding control characters and anything that travels badly in a header.
+ *
+ * `identifiers`' own `isValid` is deliberately not used: it accepts only the scheme it generates,
+ * and keys arriving here are minted by third-party clients — rejecting a well-formed UUID would
+ * break every caller doing the ordinary thing. A non-positive `maxLength` disables the length
+ * check.
+ */
+export function validateIdempotencyKey(
+  key: string,
+  maxLength: number = DEFAULT_MAX_KEY_LENGTH,
+): void {
+  if (key === "") {
+    throw new PlatformError(IdempotencyErrorCode.keyRequired, "empty idempotency key");
+  }
+  if (maxLength > 0 && key.length > maxLength) {
+    throw new PlatformError(
+      IdempotencyErrorCode.keyTooLong,
+      `idempotency key exceeds the maximum length of ${String(maxLength)}`,
+    );
+  }
+  for (const char of key) {
+    // Code units, not code points: the check is over the wire representation, and anything
+    // outside printable ASCII is rejected whole rather than decoded.
+    const code = char.charCodeAt(0);
+    if (char.length > 1 || code <= 0x20 || code > 0x7e) {
+      throw new PlatformError(
+        IdempotencyErrorCode.keyInvalid,
+        "idempotency key contains disallowed characters",
+      );
+    }
+  }
+}
+
+/**
+ * Validates a key arriving over the wire and brands it. The conversion point the branded types
+ * exist for — a handler reads the header, parses it here, and passes a typed value onward.
+ */
+export function parseIdempotencyKey(
+  key: string,
+  maxLength: number = DEFAULT_MAX_KEY_LENGTH,
+): IdempotencyKey {
+  validateIdempotencyKey(key, maxLength);
+  return key as IdempotencyKey;
+}
+
+/**
+ * Brands an already-computed fingerprint. For callers that compute their own digest instead of
+ * using this package's helpers; an empty fingerprint is rejected by `run` rather than here.
+ */
+export function asFingerprint(fingerprint: string): Fingerprint {
+  return fingerprint as Fingerprint;
+}

--- a/packages/idempotency/src/manager.node.test.ts
+++ b/packages/idempotency/src/manager.node.test.ts
@@ -1,0 +1,546 @@
+import { provideCache, type Cache } from "@primandproper/cache";
+import {
+  MemoryDistributedLock,
+  NoopDistributedLock,
+  type DistributedLock,
+} from "@primandproper/distributedlock";
+import { isPlatformError } from "@primandproper/errors";
+import { makeRecordingObserver } from "@primandproper/observability";
+import { describe, expect, it, vi } from "vitest";
+
+import type { IdempotencyConfigInput } from "./config.js";
+import { asFingerprint, IdempotencyErrorCode, parseIdempotencyKey } from "./key.js";
+import {
+  provideIdempotencyManager,
+  type IdempotencyDeps,
+  type IdempotencyManager,
+} from "./manager.node.js";
+import { RECORD_VERSION, type IdempotencyRecord } from "./record.js";
+
+interface Receipt {
+  chargeId: string;
+  charged: boolean;
+}
+
+const KEY = parseIdempotencyKey("client-minted-key");
+const FINGERPRINT = asFingerprint("fp-charge-100");
+const OTHER_FINGERPRINT = asFingerprint("fp-charge-999");
+
+/** A controllable clock, so claim expiry is exercised without real time passing. */
+function fakeClock(start = 1_000_000): {
+  now: () => number;
+  advance: (ms: number) => void;
+} {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+  };
+}
+
+/**
+ * A record store with a clock we control and failures we can switch on. The real memory cache
+ * expires against `Date.now`, which claim-expiry tests need to move faster than.
+ */
+class FakeStore<T> implements Cache<T> {
+  readonly entries = new Map<string, { value: T; expiresAt: number | undefined }>();
+  /** When set, every read and write rejects with it — the store being unreachable. */
+  failure: Error | undefined;
+  readonly writes: T[] = [];
+
+  constructor(private readonly now: () => number) {}
+
+  get(key: string): Promise<T | undefined> {
+    if (this.failure) return Promise.reject(this.failure);
+    const entry = this.entries.get(key);
+    if (entry === undefined) return Promise.resolve(undefined);
+    if (entry.expiresAt !== undefined && entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(entry.value);
+  }
+
+  set(key: string, value: T, opts?: { ttlMs?: number }): Promise<void> {
+    if (this.failure) return Promise.reject(this.failure);
+    this.writes.push(value);
+    this.entries.set(key, {
+      value,
+      expiresAt:
+        opts?.ttlMs !== undefined && opts.ttlMs > 0 ? this.now() + opts.ttlMs : undefined,
+    });
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    if (this.failure) return Promise.reject(this.failure);
+    this.entries.delete(key);
+    return Promise.resolve();
+  }
+
+  ping(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /** The single record under test, whatever key prefix the manager applied. */
+  only(): T | undefined {
+    return [...this.entries.values()][0]?.value;
+  }
+}
+
+/** The manager under test, wired to a fake clock and instant (fake) claim-lock polling. */
+function makeManager<T = Receipt>(
+  overrides: {
+    config?: IdempotencyConfigInput;
+    store?: Cache<IdempotencyRecord<T>>;
+    lock?: DistributedLock;
+    deps?: Partial<IdempotencyDeps<T>>;
+    clock?: { now: () => number; advance: (ms: number) => void };
+  } = {},
+): {
+  manager: IdempotencyManager<T>;
+  store: Cache<IdempotencyRecord<T>>;
+  clock: { now: () => number; advance: (ms: number) => void };
+} {
+  const clock = overrides.clock ?? fakeClock();
+  const store = overrides.store ?? new FakeStore<IdempotencyRecord<T>>(clock.now);
+  const manager = provideIdempotencyManager<T>(overrides.config, {
+    store,
+    lock: overrides.lock ?? new MemoryDistributedLock({}, { now: clock.now }),
+    now: clock.now,
+    // Waiting on a contended claim lock must not spend real time in tests; the clock still
+    // advances so a wait budget is honoured.
+    sleep: async (ms: number) => {
+      clock.advance(ms);
+    },
+    ...overrides.deps,
+  });
+  return { manager, store, clock };
+}
+
+const receipt = (chargeId = "ch_1"): Receipt => ({ chargeId, charged: true });
+
+describe("IdempotencyManager.run", () => {
+  it("runs the work and reports it executed", async () => {
+    const { manager } = makeManager();
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("replays a recorded result instead of running the work again", async () => {
+    const { manager } = makeManager();
+    const work = vi.fn(() => receipt());
+
+    await manager.run(KEY, FINGERPRINT, work);
+    const second = await manager.run(KEY, FINGERPRINT, work);
+
+    expect(second).toEqual({ status: "replayed", value: receipt() });
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("replays through real providers, not just the fake store", async () => {
+    const manager = provideIdempotencyManager<Receipt>(undefined, {
+      store: provideCache<IdempotencyRecord<Receipt>>({ provider: "memory" }),
+      lock: new MemoryDistributedLock(),
+    });
+    const work = vi.fn(() => receipt());
+
+    await manager.run(KEY, FINGERPRINT, work);
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
+      status: "replayed",
+      value: receipt(),
+    });
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("reports a fingerprint mismatch rather than replaying the earlier answer", async () => {
+    const { manager } = makeManager();
+    await manager.run(KEY, FINGERPRINT, () => receipt());
+    const work = vi.fn(() => receipt("ch_2"));
+
+    await expect(manager.run(KEY, OTHER_FINGERPRINT, work)).resolves.toEqual({
+      status: "fingerprint-mismatch",
+    });
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("reports a mismatch on a key reused mid-flight, in preference to in-flight", async () => {
+    // A client reusing one key for two different requests has a bug worth surfacing now;
+    // answering "in flight" would tell it to retry, which is the one thing that cannot help.
+    const { manager, store } = makeManager();
+    let release = (): void => undefined;
+    const first = manager.run(
+      KEY,
+      FINGERPRINT,
+      () =>
+        new Promise<Receipt>((resolve) => {
+          release = () => {
+            resolve(receipt());
+          };
+        }),
+    );
+    await vi.waitFor(() => {
+      expect((store as FakeStore<IdempotencyRecord<Receipt>>).only()?.state).toBe(
+        "in-flight",
+      );
+    });
+
+    await expect(manager.run(KEY, OTHER_FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "fingerprint-mismatch",
+    });
+
+    release();
+    await first;
+  });
+
+  it("refuses a second caller while the first is still running", async () => {
+    const { manager, store } = makeManager();
+    let release = (): void => undefined;
+    const work = vi.fn(
+      () =>
+        new Promise<Receipt>((resolve) => {
+          release = () => {
+            resolve(receipt());
+          };
+        }),
+    );
+
+    const first = manager.run(KEY, FINGERPRINT, work);
+    await vi.waitFor(() => {
+      expect((store as FakeStore<IdempotencyRecord<Receipt>>).only()?.state).toBe(
+        "in-flight",
+      );
+    });
+    const second = await manager.run(KEY, FINGERPRINT, work);
+
+    expect(second).toEqual({ status: "in-flight" });
+    expect(work).toHaveBeenCalledOnce();
+
+    release();
+    await expect(first).resolves.toEqual({ status: "executed", value: receipt() });
+  });
+
+  it("lets only one of two concurrent callers execute", async () => {
+    const { manager } = makeManager({ config: { lockWaitMs: 0 } });
+    const work = vi.fn(async () => {
+      await Promise.resolve();
+      return receipt();
+    });
+
+    const [a, b] = await Promise.all([
+      manager.run(KEY, FINGERPRINT, work),
+      manager.run(KEY, FINGERPRINT, work),
+    ]);
+
+    expect(work).toHaveBeenCalledOnce();
+    // One executes; the other is refused or replays, never a second execution.
+    expect([a.status, b.status].sort()).toEqual(["executed", "in-flight"]);
+  });
+
+  it("releases the claim when the work throws, so the next attempt runs again", async () => {
+    const { manager, store } = makeManager();
+    const failing = vi.fn(() => {
+      throw new Error("charge declined");
+    });
+
+    await expect(manager.run(KEY, FINGERPRINT, failing)).rejects.toThrow(
+      "charge declined",
+    );
+    expect((store as FakeStore<IdempotencyRecord<Receipt>>).entries.size).toBe(0);
+
+    await expect(manager.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+  });
+
+  it("re-runs after the claim expires, and the stale execution cannot overwrite the new owner", async () => {
+    // The one path left to a duplicate effect: work that outran inFlightTtlMs. What must not
+    // also happen is the stale execution writing its result into a slot it no longer owns.
+    const clock = fakeClock();
+    const { manager, store } = makeManager({
+      clock,
+      config: { inFlightTtlMs: 1_000 },
+      deps: {
+        generateClaimId: (() => {
+          let n = 0;
+          return () => `claim-${String(++n)}`;
+        })(),
+      },
+    });
+    const fake = store as FakeStore<IdempotencyRecord<Receipt>>;
+    let release = (): void => undefined;
+    const slow = manager.run(
+      KEY,
+      FINGERPRINT,
+      () =>
+        new Promise<Receipt>((resolve) => {
+          release = () => {
+            resolve(receipt("ch_slow"));
+          };
+        }),
+    );
+    await vi.waitFor(() => {
+      expect(fake.only()?.claimId).toBe("claim-1");
+    });
+
+    clock.advance(1_001);
+    await expect(
+      manager.run(KEY, FINGERPRINT, () => receipt("ch_fast")),
+    ).resolves.toEqual({
+      status: "executed",
+      value: receipt("ch_fast"),
+    });
+
+    release();
+    await expect(slow).resolves.toEqual({
+      status: "executed",
+      value: receipt("ch_slow"),
+    });
+    // The re-claimer's record survives: the stale execution skipped the write.
+    expect(fake.only()).toMatchObject({
+      claimId: "claim-2",
+      state: "completed",
+      value: receipt("ch_fast"),
+    });
+  });
+
+  it("declines to record a result the recordable predicate rejects", async () => {
+    // "That failure was ours, not theirs": pinning it for the whole TTL would strand a client
+    // that could have succeeded on retry.
+    const { manager, store } = makeManager({
+      deps: { recordable: (value: Receipt) => value.charged },
+    });
+    const declined: Receipt = { chargeId: "", charged: false };
+
+    await expect(manager.run(KEY, FINGERPRINT, () => declined)).resolves.toEqual({
+      status: "executed",
+      value: declined,
+    });
+    expect((store as FakeStore<IdempotencyRecord<Receipt>>).entries.size).toBe(0);
+
+    await expect(manager.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+  });
+
+  it("ignores a record written by another version rather than misreading it", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    await store.set("idempotency:" + KEY, {
+      version: RECORD_VERSION + 1,
+      state: "completed",
+      createdAt: new Date(clock.now()).toISOString(),
+      fingerprint: FINGERPRINT,
+      claimId: "from-the-old-deploy",
+      value: receipt("ch_old"),
+    });
+    const { manager } = makeManager({ clock, store });
+
+    await expect(manager.run(KEY, FINGERPRINT, () => receipt("ch_new"))).resolves.toEqual(
+      {
+        status: "executed",
+        value: receipt("ch_new"),
+      },
+    );
+    expect(store.only()).toMatchObject({
+      version: RECORD_VERSION,
+      value: receipt("ch_new"),
+    });
+  });
+
+  it("refuses a record in a state it does not understand", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    await store.set("idempotency:" + KEY, {
+      version: RECORD_VERSION,
+      state: "half-done" as IdempotencyRecord<Receipt>["state"],
+      createdAt: new Date(clock.now()).toISOString(),
+      fingerprint: FINGERPRINT,
+      claimId: "c1",
+    });
+    const { manager } = makeManager({ clock, store });
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
+      status: "in-flight",
+    });
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("writes the claim and the result with their own TTLs", async () => {
+    const { manager, store } = makeManager({
+      config: { inFlightTtlMs: 1_000, ttlMs: 60_000 },
+    });
+    const fake = store as FakeStore<IdempotencyRecord<Receipt>>;
+    const setSpy = vi.spyOn(fake, "set");
+
+    await manager.run(KEY, FINGERPRINT, () => receipt());
+
+    expect(setSpy.mock.calls.map(([, , opts]) => opts?.ttlMs)).toEqual([1_000, 60_000]);
+  });
+
+  it("takes a per-call retention override", async () => {
+    const { manager, store } = makeManager({ config: { ttlMs: 60_000 } });
+    const setSpy = vi.spyOn(store as FakeStore<IdempotencyRecord<Receipt>>, "set");
+
+    await manager.run(KEY, FINGERPRINT, () => receipt(), { ttlMs: 5_000 });
+
+    expect(setSpy.mock.calls[1]?.[2]?.ttlMs).toBe(5_000);
+  });
+
+  it("rejects a key past the configured maximum before running anything", async () => {
+    const { manager } = makeManager({ config: { maxKeyLength: 8 } });
+    const work = vi.fn(() => receipt());
+
+    await expect(
+      manager.run(parseIdempotencyKey("way-too-long-to-accept"), FINGERPRINT, work),
+    ).rejects.toSatisfy((err) => isPlatformError(err, IdempotencyErrorCode.keyTooLong));
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty fingerprint rather than defaulting it", async () => {
+    // A default would make every request for a key look identical and disable mismatch
+    // detection entirely.
+    const { manager } = makeManager();
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, asFingerprint(""), work)).rejects.toSatisfy((err) =>
+      isPlatformError(err, IdempotencyErrorCode.fingerprintRequired),
+    );
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("observes the key, the fingerprint, and the replay", async () => {
+    const observer = makeRecordingObserver();
+    const { manager } = makeManager({ deps: { observer } });
+
+    await manager.run(KEY, FINGERPRINT, () => receipt());
+    await manager.run(KEY, FINGERPRINT, () => receipt());
+
+    expect(observer.observations).toContainEqual(
+      expect.objectContaining({ key: "idempotency.key", value: KEY }),
+    );
+    expect(observer.observations).toContainEqual(
+      expect.objectContaining({ key: "idempotency.replayed", value: true }),
+    );
+  });
+});
+
+describe("store failure policy", () => {
+  it("fail-closed refuses the request rather than risking a duplicate effect", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    const { manager } = makeManager({ clock, store });
+    store.failure = new Error("redis is down");
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).rejects.toSatisfy((err) =>
+      isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
+    );
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("fail-open runs the work anyway, trading the guarantee for availability", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    const { manager } = makeManager({
+      clock,
+      store,
+      config: { storeFailurePolicy: "fail-open" },
+    });
+    store.failure = new Error("redis is down");
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("applies the policy to a failed claim write too, not only to reads", async () => {
+    const clock = fakeClock();
+    const failingWrites = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    vi.spyOn(failingWrites, "set").mockRejectedValue(new Error("redis is down"));
+
+    const closed = makeManager({ clock, store: failingWrites }).manager;
+    await expect(closed.run(KEY, FINGERPRINT, () => receipt())).rejects.toSatisfy((err) =>
+      isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
+    );
+
+    const open = makeManager({
+      clock,
+      store: failingWrites,
+      config: { storeFailurePolicy: "fail-open" },
+    }).manager;
+    await expect(open.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+  });
+
+  it("applies the policy when the locker itself fails", async () => {
+    const clock = fakeClock();
+    const lock: DistributedLock = {
+      acquire: () => Promise.reject(new Error("lock store down")),
+      ping: () => Promise.resolve(),
+      close: () => Promise.resolve(),
+    };
+
+    const closed = makeManager({ clock, lock }).manager;
+    await expect(closed.run(KEY, FINGERPRINT, () => receipt())).rejects.toSatisfy((err) =>
+      isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
+    );
+
+    const open = makeManager({
+      clock,
+      lock,
+      config: { storeFailurePolicy: "fail-open" },
+    }).manager;
+    await expect(open.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+  });
+
+  it("keeps the store error as the cause, so the operator can see what broke", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    const { manager } = makeManager({ clock, store });
+    const cause = new Error("ECONNREFUSED");
+    store.failure = cause;
+
+    await expect(manager.run(KEY, FINGERPRINT, () => receipt())).rejects.toMatchObject({
+      cause,
+    });
+  });
+});
+
+describe("the locker matters", () => {
+  it("still replays under the noop locker — but grants every claim", async () => {
+    // Documented, not endorsed: replay covers the ordinary timeout-then-retry case, while two
+    // genuinely concurrent requests can both claim and both execute.
+    const { manager } = makeManager({ lock: new NoopDistributedLock() });
+
+    await manager.run(KEY, FINGERPRINT, () => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
+      status: "replayed",
+      value: receipt(),
+    });
+  });
+});

--- a/packages/idempotency/src/manager.node.test.ts
+++ b/packages/idempotency/src/manager.node.test.ts
@@ -454,7 +454,62 @@ describe("store failure policy", () => {
     expect(work).not.toHaveBeenCalled();
   });
 
-  it("fail-open runs the work anyway, trading the guarantee for availability", async () => {
+  it("fail-open treats a failed read as a miss and runs the work", async () => {
+    const clock = fakeClock();
+    const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+    // Reads fail, writes still land — the shape fail-open exists for.
+    vi.spyOn(store, "get").mockRejectedValue(new Error("redis read timeout"));
+    const { manager } = makeManager({
+      clock,
+      store,
+      config: { storeFailurePolicy: "fail-open" },
+    });
+    const work = vi.fn(() => receipt());
+
+    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
+      status: "executed",
+      value: receipt(),
+    });
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a failed claim write under either policy — the policy governs reads only", async () => {
+    // A claim that could not be written leaves the completion nothing to prove ownership
+    // against, so there is no state in which running the work is a defensible guess. Matching
+    // platform-go, which lets a Set failure fail the request regardless of FailOpen.
+    for (const storeFailurePolicy of ["fail-closed", "fail-open"] as const) {
+      const clock = fakeClock();
+      const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
+      vi.spyOn(store, "set").mockRejectedValue(new Error("redis is down"));
+      const { manager } = makeManager({ clock, store, config: { storeFailurePolicy } });
+      const work = vi.fn(() => receipt());
+
+      await expect(manager.run(KEY, FINGERPRINT, work)).rejects.toSatisfy((err) =>
+        isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
+      );
+      expect(work).not.toHaveBeenCalled();
+    }
+  });
+
+  it("refuses when the locker itself fails, under either policy", async () => {
+    const lock: DistributedLock = {
+      acquire: () => Promise.reject(new Error("lock store down")),
+      ping: () => Promise.resolve(),
+      close: () => Promise.resolve(),
+    };
+
+    for (const storeFailurePolicy of ["fail-closed", "fail-open"] as const) {
+      const { manager } = makeManager({ lock, config: { storeFailurePolicy } });
+      const work = vi.fn(() => receipt());
+
+      await expect(manager.run(KEY, FINGERPRINT, work)).rejects.toSatisfy((err) =>
+        isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
+      );
+      expect(work).not.toHaveBeenCalled();
+    }
+  });
+
+  it("fail-open on a wholly unreachable store still refuses, because the claim cannot land", async () => {
     const clock = fakeClock();
     const store = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
     const { manager } = makeManager({
@@ -465,56 +520,10 @@ describe("store failure policy", () => {
     store.failure = new Error("redis is down");
     const work = vi.fn(() => receipt());
 
-    await expect(manager.run(KEY, FINGERPRINT, work)).resolves.toEqual({
-      status: "executed",
-      value: receipt(),
-    });
-    expect(work).toHaveBeenCalledOnce();
-  });
-
-  it("applies the policy to a failed claim write too, not only to reads", async () => {
-    const clock = fakeClock();
-    const failingWrites = new FakeStore<IdempotencyRecord<Receipt>>(clock.now);
-    vi.spyOn(failingWrites, "set").mockRejectedValue(new Error("redis is down"));
-
-    const closed = makeManager({ clock, store: failingWrites }).manager;
-    await expect(closed.run(KEY, FINGERPRINT, () => receipt())).rejects.toSatisfy((err) =>
+    await expect(manager.run(KEY, FINGERPRINT, work)).rejects.toSatisfy((err) =>
       isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
     );
-
-    const open = makeManager({
-      clock,
-      store: failingWrites,
-      config: { storeFailurePolicy: "fail-open" },
-    }).manager;
-    await expect(open.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
-      status: "executed",
-      value: receipt(),
-    });
-  });
-
-  it("applies the policy when the locker itself fails", async () => {
-    const clock = fakeClock();
-    const lock: DistributedLock = {
-      acquire: () => Promise.reject(new Error("lock store down")),
-      ping: () => Promise.resolve(),
-      close: () => Promise.resolve(),
-    };
-
-    const closed = makeManager({ clock, lock }).manager;
-    await expect(closed.run(KEY, FINGERPRINT, () => receipt())).rejects.toSatisfy((err) =>
-      isPlatformError(err, IdempotencyErrorCode.storeUnavailable),
-    );
-
-    const open = makeManager({
-      clock,
-      lock,
-      config: { storeFailurePolicy: "fail-open" },
-    }).manager;
-    await expect(open.run(KEY, FINGERPRINT, () => receipt())).resolves.toEqual({
-      status: "executed",
-      value: receipt(),
-    });
+    expect(work).not.toHaveBeenCalled();
   });
 
   it("keeps the store error as the cause, so the operator can see what broke", async () => {

--- a/packages/idempotency/src/manager.node.ts
+++ b/packages/idempotency/src/manager.node.ts
@@ -1,0 +1,539 @@
+import type { Cache } from "@primandproper/cache";
+import type { DistributedLock } from "@primandproper/distributedlock";
+import { isPlatformError, messageOf, PlatformError } from "@primandproper/errors";
+import { provideIdentifierGenerator } from "@primandproper/identifiers";
+import {
+  makeObserver,
+  type ObservabilityDeps,
+  type Observer,
+  type Operation,
+} from "@primandproper/observability";
+
+import { IdempotencyConfigSchema, type IdempotencyConfigInput } from "./config.js";
+import { idempotencyInstruments, type IdempotencyInstruments } from "./instruments.js";
+import {
+  IdempotencyErrorCode,
+  validateIdempotencyKey,
+  type Fingerprint,
+  type IdempotencyKey,
+} from "./key.js";
+import {
+  RECORD_VERSION,
+  type IdempotencyRecord,
+  type IdempotentResult,
+} from "./record.js";
+import { withLock, type LockAttempt } from "./with-lock.node.js";
+
+const o11yName = "idempotency";
+
+/**
+ * What a manager needs at runtime. The store and the locker are required and have no defaults:
+ * an implicit noop locker would leave replay working while quietly removing mutual exclusion,
+ * which is the failure mode hardest to notice and most expensive to meet.
+ */
+export interface IdempotencyDeps<T> extends ObservabilityDeps {
+  /**
+   * Where records live. Use a cross-process provider (redis) in production: the memory provider
+   * is per-process, so replicas would not see each other's records.
+   */
+  store: Cache<IdempotencyRecord<T>>;
+  /**
+   * The lock guarding the claim. Note that `noop` acquires unconditionally — with it, replay
+   * still works (which covers the ordinary timeout-then-retry case) but two genuinely concurrent
+   * requests can both claim and both execute.
+   */
+  lock: DistributedLock;
+  /**
+   * Decides whether a result is worth recording. A result it rejects releases the claim instead,
+   * so the next attempt runs the work again.
+   *
+   * This is how a caller says "that failure was ours, not theirs": a server-side error usually
+   * means the effect did not land, and pinning it for the whole TTL would strand a client that
+   * could have succeeded on retry. Defaults to recording everything the work returns.
+   */
+  recordable?: (value: T) => boolean;
+  /** Injectable clock for record timestamps and the claim-lock wait, for deterministic tests. */
+  now?: () => number;
+  /** Injectable delay for the claim-lock wait, for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable claim-id generation, for deterministic tests. */
+  generateClaimId?: () => string;
+}
+
+/** Per-call overrides. */
+export interface RunOptions {
+  /**
+   * Overrides how long *this* call's completed record is retained, in milliseconds.
+   *
+   * Retention is the window in which a retry replays instead of re-running, so it belongs to the
+   * operation rather than to the manager: a payment worth protecting for a day and a profile
+   * update worth protecting for a minute can then share one manager. There is deliberately no
+   * per-call `inFlightTtlMs` — that bounds how long a dead process blocks a retry, which is a
+   * property of the deployment rather than of the call.
+   */
+  ttlMs?: number;
+}
+
+/** Outcomes reported on `idempotency.requests`; the four together are the request total. */
+type Outcome = "executed" | "replayed" | "in_flight" | "mismatch";
+
+/** What claiming a key produced. */
+type Claim<T> =
+  /** The claim is ours, and `claimId` is what proves it at completion time. */
+  | { kind: "claimed"; claimId: string }
+  /** Someone landed a record between the pre-lock read and the lock. */
+  | { kind: "existing"; record: IdempotencyRecord<T> }
+  /** The claim lock stayed held for the whole wait — someone else is claiming this key now. */
+  | { kind: "contended" }
+  /** The store or the locker failed and the policy is fail-open: run the work unprotected. */
+  | { kind: "unprotected" };
+
+/** Sentinel for "the store failed and we are failing open" on a read. */
+const FAILED_OPEN = Symbol("failed-open");
+
+const defaultIdentifiers = provideIdentifierGenerator();
+
+/**
+ * Runs work at most once per client-supplied key.
+ *
+ * A concrete class rather than an interface: there is one implementation, and the seams worth
+ * swapping — the store and the locker — are already interfaces of their own.
+ *
+ * What it guarantees is at-most-once **effect**, not exactly-once. The gap is worth naming: work
+ * that has its effect and *then* fails is not covered. The charge landed, the error came back,
+ * nothing was recorded, and the retry charges again. Recording failures instead would be worse —
+ * a transient error would be pinned for the whole TTL and the client could never succeed — which
+ * is what {@link IdempotencyDeps.recordable} exists to let a caller tune.
+ */
+export class IdempotencyManager<T> {
+  readonly #store: Cache<IdempotencyRecord<T>>;
+  readonly #lock: DistributedLock;
+  readonly #observer: Observer;
+  readonly #instruments: IdempotencyInstruments;
+  readonly #recordable: (value: T) => boolean;
+  readonly #now: () => number;
+  readonly #newClaimId: () => string;
+  readonly #keyPrefix: string;
+  readonly #ttlMs: number;
+  readonly #inFlightTtlMs: number;
+  readonly #maxKeyLength: number;
+  readonly #failOpen: boolean;
+  readonly #lockTtlMs: number;
+  readonly #lockWaitMs: number;
+  readonly #lockPollMs: number;
+  readonly #sleep: ((ms: number) => Promise<void>) | undefined;
+
+  constructor(config: IdempotencyConfigInput | undefined, deps: IdempotencyDeps<T>) {
+    const cfg = IdempotencyConfigSchema.parse(config ?? {});
+    this.#store = deps.store;
+    this.#lock = deps.lock;
+    this.#observer = deps.observer ?? makeObserver(o11yName, deps);
+    this.#instruments = idempotencyInstruments(o11yName, deps);
+    this.#recordable = deps.recordable ?? ((): boolean => true);
+    this.#now = deps.now ?? ((): number => Date.now());
+    this.#newClaimId =
+      deps.generateClaimId ?? ((): string => defaultIdentifiers.generate());
+    this.#sleep = deps.sleep;
+    this.#keyPrefix = cfg.keyPrefix;
+    this.#ttlMs = cfg.ttlMs;
+    this.#inFlightTtlMs = cfg.inFlightTtlMs;
+    this.#maxKeyLength = cfg.maxKeyLength;
+    this.#failOpen = cfg.storeFailurePolicy === "fail-open";
+    this.#lockTtlMs = cfg.lockTtlMs;
+    this.#lockWaitMs = cfg.lockWaitMs;
+    this.#lockPollMs = cfg.lockPollMs;
+  }
+
+  /**
+   * Runs `fn` at most once for `key`.
+   *
+   * The protocol is four steps, and the order is the correctness argument:
+   *
+   * 1. read the record — replay, refuse, or continue;
+   * 2. lock → **re-read** → write an in-flight claim → unlock;
+   * 3. run the work *outside* the lock;
+   * 4. record the result, or release the claim.
+   *
+   * The re-read inside the lock is what makes it correct: two callers that both missed the
+   * pre-lock read would otherwise both claim, and the second would overwrite the first.
+   *
+   * The work runs outside the lock because a held lock is a held resource (the postgres lock
+   * provider runs inside a transaction — an open transaction per in-flight request means pool
+   * exhaustion and blocked vacuums), because lock leases are shorter than real work (anything
+   * slower loses mutual exclusion *while still running*), and because a lock leaves no evidence:
+   * kill a process mid-execution and the lock evaporates, while a *record* with its own TTL
+   * survives and correctly refuses the retry until it expires.
+   *
+   * An error thrown by `fn` propagates unchanged and the claim is released, so the next attempt
+   * runs the work again. An unusable key, an empty fingerprint, or an unreachable store under
+   * `fail-closed` throw a {@link PlatformError}; the four ordinary outcomes are returned, not
+   * thrown.
+   */
+  run(
+    key: IdempotencyKey,
+    fingerprint: Fingerprint,
+    fn: () => Promise<T> | T,
+    options: RunOptions = {},
+  ): Promise<IdempotentResult<T>> {
+    return this.#observer.run("run", async (op) => {
+      validateIdempotencyKey(key, this.#maxKeyLength);
+      if (fingerprint === "") {
+        // Defaulting it would make every request for a key look identical and disable mismatch
+        // detection entirely, so it is rejected rather than filled in.
+        throw new PlatformError(
+          IdempotencyErrorCode.fingerprintRequired,
+          "empty idempotency fingerprint",
+        );
+      }
+
+      op.set("idempotency.key", key).set("idempotency.fingerprint", fingerprint);
+
+      const ttlMs =
+        options.ttlMs !== undefined && options.ttlMs > 0 ? options.ttlMs : this.#ttlMs;
+      const storeKey = this.#storeKey(key);
+
+      // Read before locking. The overwhelmingly common case is a replay of a completed record,
+      // and it costs one round trip with no coordination at all.
+      const existing = await this.#load(op, storeKey);
+      if (existing !== undefined && existing !== FAILED_OPEN) {
+        return this.#resolve(op, existing, fingerprint);
+      }
+
+      const claim = await this.#claim(op, key, storeKey, fingerprint);
+      switch (claim.kind) {
+        case "existing":
+          return this.#resolve(op, claim.record, fingerprint);
+        case "contended":
+          // Someone else holds the claim lock for this key right now, so they are about to write
+          // (or have just written) an in-flight record. Refusing is the same answer that record
+          // would produce, one round trip earlier.
+          op.logger().debug("claim lock contended; reporting in flight");
+          this.#count("in_flight");
+          return { status: "in-flight" };
+        case "claimed":
+        case "unprotected":
+          break;
+      }
+
+      const claimId = claim.kind === "claimed" ? claim.claimId : undefined;
+
+      let value: T;
+      try {
+        value = await fn();
+      } catch (err) {
+        if (claimId !== undefined) {
+          await this.#release(op, storeKey, claimId);
+        }
+        throw err;
+      }
+
+      if (claimId === undefined) {
+        // Ran without a claim under fail-open: there is no claim to complete, and writing a
+        // record now would pin a result the store could not be trusted to guard in the first
+        // place.
+        op.set("idempotency.recorded", false);
+        this.#count("executed");
+        return { status: "executed", value };
+      }
+
+      if (!this.#recordable(value)) {
+        op.set("idempotency.recorded", false);
+        await this.#release(op, storeKey, claimId);
+        this.#count("executed");
+        return { status: "executed", value };
+      }
+
+      await this.#commit(op, storeKey, claimId, fingerprint, value, ttlMs);
+      this.#count("executed");
+      return { status: "executed", value };
+    });
+  }
+
+  /**
+   * Turns a stored record into an answer.
+   *
+   * The fingerprint is checked before the state, deliberately: a client reusing one key for two
+   * different requests has a bug worth surfacing immediately, and answering `in-flight` instead
+   * would tell it to retry — the one thing that cannot help.
+   */
+  #resolve(
+    op: Operation,
+    record: IdempotencyRecord<T>,
+    fingerprint: Fingerprint,
+  ): IdempotentResult<T> {
+    if (record.fingerprint !== fingerprint) {
+      op.logger().warn("idempotency key reused with a different request");
+      this.#count("mismatch");
+      return { status: "fingerprint-mismatch" };
+    }
+
+    switch (record.state) {
+      case "completed":
+        op.set("idempotency.replayed", true);
+        this.#count("replayed");
+        // A completed record without a value is one whose work returned `undefined`; the state
+        // is what says it finished, so the value is replayed as it was stored.
+        return { status: "replayed", value: record.value as T };
+      case "in-flight":
+        this.#count("in_flight");
+        return { status: "in-flight" };
+      default:
+        // A state this build does not know is treated like a shape it cannot read: refuse rather
+        // than guess, since the alternative is running work that may already have run.
+        this.#instruments.staleRecords.add(1);
+        op.logger().warn("ignoring idempotency record in an unknown state");
+        this.#count("in_flight");
+        return { status: "in-flight" };
+    }
+  }
+
+  /**
+   * Writes the in-flight record under the lock, returning either the claim id it took or the
+   * record that made claiming unnecessary. The lock covers a re-read and a write and nothing
+   * else.
+   */
+  async #claim(
+    op: Operation,
+    key: IdempotencyKey,
+    storeKey: string,
+    fingerprint: Fingerprint,
+  ): Promise<Claim<T>> {
+    let attempt: LockAttempt<Claim<T>>;
+    try {
+      attempt = await withLock<Claim<T>>(
+        this.#lock,
+        this.#lockKey(key),
+        async () => {
+          const existing = await this.#load(op, storeKey);
+          if (existing === FAILED_OPEN) {
+            return { kind: "unprotected" };
+          }
+          if (existing !== undefined) {
+            return { kind: "existing", record: existing };
+          }
+
+          const claimId = this.#newClaimId();
+          await this.#store.set(
+            storeKey,
+            {
+              version: RECORD_VERSION,
+              state: "in-flight",
+              createdAt: new Date(this.#now()).toISOString(),
+              fingerprint,
+              claimId,
+            },
+            { ttlMs: this.#inFlightTtlMs },
+          );
+          return { kind: "claimed", claimId };
+        },
+        {
+          ttlMs: this.#lockTtlMs,
+          waitMs: this.#lockWaitMs,
+          pollMs: this.#lockPollMs,
+          now: this.#now,
+          onReleaseError: (err) => {
+            op.acknowledge(err, "releasing idempotency claim lock");
+          },
+          ...(this.#sleep !== undefined ? { sleep: this.#sleep } : {}),
+        },
+      );
+    } catch (err) {
+      // A read inside the lock that already went through the policy is re-thrown untouched;
+      // wrapping it again would double-count the store error and bury the original message.
+      if (isPlatformError(err, IdempotencyErrorCode.storeUnavailable)) {
+        throw err;
+      }
+      // Either the locker itself failed or the claim write did. Both are the store being
+      // unreachable, so both go through the same policy the read does — otherwise `fail-open`
+      // would be a promise this package keeps only for reads.
+      this.#instruments.storeErrors.add(1);
+      if (!this.#failOpen) {
+        throw new PlatformError(
+          IdempotencyErrorCode.storeUnavailable,
+          `claiming idempotency key: ${messageOf(err)}`,
+          { cause: err },
+        );
+      }
+      op.acknowledge(err, "claiming idempotency key, failing open");
+      return { kind: "unprotected" };
+    }
+
+    return attempt.acquired ? attempt.value : { kind: "contended" };
+  }
+
+  /**
+   * Records a finished result, but only if the claim is still ours.
+   *
+   * A failure here is counted and logged, never thrown: the work already happened and the caller
+   * is entitled to its result. What the caller loses is the replay, so the next attempt runs the
+   * work again — which is exactly what `idempotency.record.failures` is for.
+   */
+  async #commit(
+    op: Operation,
+    storeKey: string,
+    claimId: string,
+    fingerprint: Fingerprint,
+    value: T,
+    ttlMs: number,
+  ): Promise<void> {
+    if (!(await this.#stillOurs(op, storeKey, claimId, "completing"))) {
+      return;
+    }
+
+    try {
+      await this.#store.set(
+        storeKey,
+        {
+          version: RECORD_VERSION,
+          state: "completed",
+          createdAt: new Date(this.#now()).toISOString(),
+          fingerprint,
+          claimId,
+          value,
+        },
+        { ttlMs },
+      );
+      op.set("idempotency.recorded", true);
+    } catch (err) {
+      this.#instruments.recordFailures.add(1);
+      op.acknowledge(err, "recording idempotency result");
+    }
+  }
+
+  /**
+   * Drops our claim so the next attempt can run the work again.
+   *
+   * Best-effort by design: if it fails, the claim expires on its own `inFlightTtlMs` and callers
+   * are refused until then. Surfacing the failure would replace a delay with an error for work
+   * that already completed.
+   */
+  async #release(op: Operation, storeKey: string, claimId: string): Promise<void> {
+    if (!(await this.#stillOurs(op, storeKey, claimId, "releasing"))) {
+      return;
+    }
+
+    try {
+      await this.#store.delete(storeKey);
+    } catch (err) {
+      op.acknowledge(err, "releasing idempotency claim");
+    }
+  }
+
+  /**
+   * Reports whether the stored record is still the claim this execution took.
+   *
+   * It is false when the work outran `inFlightTtlMs`, the claim expired, and someone else
+   * re-claimed the key — the one remaining path to a duplicate effect, and the reason
+   * `idempotency.claims.lost` is the counter to alert on. Writing through it would compound the
+   * problem by handing the new owner a result from a different execution.
+   */
+  async #stillOurs(
+    op: Operation,
+    storeKey: string,
+    claimId: string,
+    action: string,
+  ): Promise<boolean> {
+    let record: IdempotencyRecord<T> | typeof FAILED_OPEN | undefined;
+    try {
+      record = await this.#load(op, storeKey);
+    } catch (err) {
+      this.#instruments.recordFailures.add(1);
+      op.acknowledge(err, `reading idempotency claim before ${action}`);
+      return false;
+    }
+    if (record === FAILED_OPEN) {
+      return false;
+    }
+
+    if (record?.claimId !== claimId) {
+      this.#instruments.claimsLost.add(1);
+      op.logger().warn(
+        "idempotency claim lost before it could be completed; the work may run again",
+        { "idempotency.claim_id": claimId, "idempotency.action": action },
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Reads a record, reporting `undefined` when there is nothing usable to this build.
+   *
+   * A record written by a different version reads as absent rather than as an error: with a
+   * day-long TTL, failing on it would turn one bad deploy into a day of failures. A store failure
+   * is the case the policy exists for — `fail-closed` throws, `fail-open` reports
+   * {@link FAILED_OPEN} so the caller can tell "nothing recorded" from "we could not look".
+   */
+  async #load(
+    op: Operation,
+    storeKey: string,
+  ): Promise<IdempotencyRecord<T> | typeof FAILED_OPEN | undefined> {
+    let record: IdempotencyRecord<T> | undefined;
+    try {
+      record = await this.#store.get(storeKey);
+    } catch (err) {
+      this.#instruments.storeErrors.add(1);
+      if (!this.#failOpen) {
+        throw new PlatformError(
+          IdempotencyErrorCode.storeUnavailable,
+          `reading idempotency record: ${messageOf(err)}`,
+          { cause: err },
+        );
+      }
+      op.acknowledge(err, "reading idempotency record, failing open");
+      return FAILED_OPEN;
+    }
+
+    if (record === undefined) {
+      return undefined;
+    }
+
+    if (record.version !== RECORD_VERSION) {
+      this.#instruments.staleRecords.add(1);
+      op.logger().debug(
+        "ignoring idempotency record written by a different record version",
+        {
+          "idempotency.record_version": record.version,
+        },
+      );
+      return undefined;
+    }
+
+    return record;
+  }
+
+  /** Records one resolved request against its outcome. */
+  #count(outcome: Outcome): void {
+    this.#instruments.requests.add(1, { outcome });
+  }
+
+  /** Namespaces a caller's key for the record store. */
+  #storeKey(key: IdempotencyKey): string {
+    return `${this.#keyPrefix}${key}`;
+  }
+
+  /**
+   * Namespaces a caller's key for the locker. Deliberately distinct from the store key: the two
+   * live in different systems, and a shared spelling invites the assumption that one can be
+   * derived from the other.
+   */
+  #lockKey(key: IdempotencyKey): string {
+    return `${this.#keyPrefix}lock:${key}`;
+  }
+}
+
+/**
+ * Validates config (applying defaults) and returns an {@link IdempotencyManager}. The analogue of
+ * the Go platform's `idempotencycfg.NewManager`, minus the nested store/locker config: both are
+ * built by their own packages' factories and passed in, which is how this repo composes.
+ *
+ * The result type is the caller's, and it cannot be inferred from the arguments, so it is spelled
+ * out at the call site: `provideIdempotencyManager<Receipt>(cfg, { store, lock })`.
+ */
+export function provideIdempotencyManager<T>(
+  config: IdempotencyConfigInput | undefined,
+  deps: IdempotencyDeps<T>,
+): IdempotencyManager<T> {
+  return new IdempotencyManager<T>(config, deps);
+}

--- a/packages/idempotency/src/manager.node.ts
+++ b/packages/idempotency/src/manager.node.ts
@@ -84,12 +84,7 @@ type Claim<T> =
   /** Someone landed a record between the pre-lock read and the lock. */
   | { kind: "existing"; record: IdempotencyRecord<T> }
   /** The claim lock stayed held for the whole wait — someone else is claiming this key now. */
-  | { kind: "contended" }
-  /** The store or the locker failed and the policy is fail-open: run the work unprotected. */
-  | { kind: "unprotected" };
-
-/** Sentinel for "the store failed and we are failing open" on a read. */
-const FAILED_OPEN = Symbol("failed-open");
+  | { kind: "contended" };
 
 const defaultIdentifiers = provideIdentifierGenerator();
 
@@ -165,9 +160,8 @@ export class IdempotencyManager<T> {
    * survives and correctly refuses the retry until it expires.
    *
    * An error thrown by `fn` propagates unchanged and the claim is released, so the next attempt
-   * runs the work again. An unusable key, an empty fingerprint, or an unreachable store under
-   * `fail-closed` throw a {@link PlatformError}; the four ordinary outcomes are returned, not
-   * thrown.
+   * runs the work again. An unusable key, an empty fingerprint, or an unreachable store throw a
+   * {@link PlatformError}; the four ordinary outcomes are returned, not thrown.
    */
   run(
     key: IdempotencyKey,
@@ -195,7 +189,7 @@ export class IdempotencyManager<T> {
       // Read before locking. The overwhelmingly common case is a replay of a completed record,
       // and it costs one round trip with no coordination at all.
       const existing = await this.#load(op, storeKey);
-      if (existing !== undefined && existing !== FAILED_OPEN) {
+      if (existing !== undefined) {
         return this.#resolve(op, existing, fingerprint);
       }
 
@@ -211,29 +205,17 @@ export class IdempotencyManager<T> {
           this.#count("in_flight");
           return { status: "in-flight" };
         case "claimed":
-        case "unprotected":
           break;
       }
 
-      const claimId = claim.kind === "claimed" ? claim.claimId : undefined;
+      const { claimId } = claim;
 
       let value: T;
       try {
         value = await fn();
       } catch (err) {
-        if (claimId !== undefined) {
-          await this.#release(op, storeKey, claimId);
-        }
+        await this.#release(op, storeKey, claimId);
         throw err;
-      }
-
-      if (claimId === undefined) {
-        // Ran without a claim under fail-open: there is no claim to complete, and writing a
-        // record now would pin a result the store could not be trusted to guard in the first
-        // place.
-        op.set("idempotency.recorded", false);
-        this.#count("executed");
-        return { status: "executed", value };
       }
 
       if (!this.#recordable(value)) {
@@ -305,9 +287,6 @@ export class IdempotencyManager<T> {
         this.#lockKey(key),
         async () => {
           const existing = await this.#load(op, storeKey);
-          if (existing === FAILED_OPEN) {
-            return { kind: "unprotected" };
-          }
           if (existing !== undefined) {
             return { kind: "existing", record: existing };
           }
@@ -343,19 +322,17 @@ export class IdempotencyManager<T> {
       if (isPlatformError(err, IdempotencyErrorCode.storeUnavailable)) {
         throw err;
       }
-      // Either the locker itself failed or the claim write did. Both are the store being
-      // unreachable, so both go through the same policy the read does — otherwise `fail-open`
-      // would be a promise this package keeps only for reads.
+      // Either the locker failed or the claim write did, and neither consults the store-failure
+      // policy: it governs *reads* only. A read can fail open because "no record" is a coherent
+      // (if unprotected) answer to carry on from; a claim that could not be written leaves
+      // nothing for the completion to prove ownership against, so there is no state in which
+      // running the work is a defensible guess. platform-go draws the line in the same place.
       this.#instruments.storeErrors.add(1);
-      if (!this.#failOpen) {
-        throw new PlatformError(
-          IdempotencyErrorCode.storeUnavailable,
-          `claiming idempotency key: ${messageOf(err)}`,
-          { cause: err },
-        );
-      }
-      op.acknowledge(err, "claiming idempotency key, failing open");
-      return { kind: "unprotected" };
+      throw new PlatformError(
+        IdempotencyErrorCode.storeUnavailable,
+        `claiming idempotency key: ${messageOf(err)}`,
+        { cause: err },
+      );
     }
 
     return attempt.acquired ? attempt.value : { kind: "contended" };
@@ -433,7 +410,7 @@ export class IdempotencyManager<T> {
     claimId: string,
     action: string,
   ): Promise<boolean> {
-    let record: IdempotencyRecord<T> | typeof FAILED_OPEN | undefined;
+    let record: IdempotencyRecord<T> | undefined;
     try {
       record = await this.#load(op, storeKey);
     } catch (err) {
@@ -441,10 +418,10 @@ export class IdempotencyManager<T> {
       op.acknowledge(err, `reading idempotency claim before ${action}`);
       return false;
     }
-    if (record === FAILED_OPEN) {
-      return false;
-    }
 
+    // A read that failed open arrives here as `undefined` and is therefore counted as a lost
+    // claim. That is the honest reading: we could not confirm the claim is ours, and the write
+    // is skipped for the same reason it would be if someone else had taken it.
     if (record?.claimId !== claimId) {
       this.#instruments.claimsLost.add(1);
       op.logger().warn(
@@ -461,14 +438,17 @@ export class IdempotencyManager<T> {
    * Reads a record, reporting `undefined` when there is nothing usable to this build.
    *
    * A record written by a different version reads as absent rather than as an error: with a
-   * day-long TTL, failing on it would turn one bad deploy into a day of failures. A store failure
-   * is the case the policy exists for — `fail-closed` throws, `fail-open` reports
-   * {@link FAILED_OPEN} so the caller can tell "nothing recorded" from "we could not look".
+   * day-long TTL, failing on it would turn one bad deploy into a day of failures.
+   *
+   * **This is the only place the store-failure policy applies.** `fail-closed` throws;
+   * `fail-open` reports the read as a miss and carries on, which is what trades the guarantee for
+   * availability. The two are indistinguishable to the caller by design — "nothing recorded" is
+   * exactly the answer fail-open elects to proceed from.
    */
   async #load(
     op: Operation,
     storeKey: string,
-  ): Promise<IdempotencyRecord<T> | typeof FAILED_OPEN | undefined> {
+  ): Promise<IdempotencyRecord<T> | undefined> {
     let record: IdempotencyRecord<T> | undefined;
     try {
       record = await this.#store.get(storeKey);
@@ -482,7 +462,7 @@ export class IdempotencyManager<T> {
         );
       }
       op.acknowledge(err, "reading idempotency record, failing open");
-      return FAILED_OPEN;
+      return undefined;
     }
 
     if (record === undefined) {

--- a/packages/idempotency/src/record.test.ts
+++ b/packages/idempotency/src/record.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { hasValue, type IdempotentResult } from "./record.js";
+
+describe("hasValue", () => {
+  it("narrows the two outcomes that carry a value", () => {
+    const executed: IdempotentResult<number> = { status: "executed", value: 1 };
+    const replayed: IdempotentResult<number> = { status: "replayed", value: 2 };
+
+    for (const result of [executed, replayed]) {
+      expect(hasValue(result)).toBe(true);
+      // The point of the guard: `result.value` is reachable without a cast in this branch.
+      if (hasValue(result)) {
+        expect(typeof result.value).toBe("number");
+      }
+    }
+  });
+
+  it("rejects the two outcomes that do not", () => {
+    expect(hasValue<number>({ status: "in-flight" })).toBe(false);
+    expect(hasValue<number>({ status: "fingerprint-mismatch" })).toBe(false);
+  });
+});

--- a/packages/idempotency/src/record.ts
+++ b/packages/idempotency/src/record.ts
@@ -1,0 +1,76 @@
+/**
+ * The record shape this build writes and reads.
+ *
+ * Every record carries it, and a record stamped with anything else is **ignored rather than
+ * misread** — see {@link IdempotencyRecord.version}. Bump it whenever the stored shape changes.
+ */
+export const RECORD_VERSION = 1;
+
+/** The lifecycle stage of a record. */
+export type RecordState =
+  /** A claim: work has started and has not reported back. */
+  | "in-flight"
+  /** A finished result, safe to replay. */
+  | "completed";
+
+/**
+ * What the store holds for a key. Written twice per execution: once to claim the key, once to
+ * record the outcome.
+ *
+ * `T` must survive the store's round trip. The redis cache provider serialises with JSON, so
+ * `Date`/`Map`/`Set` come back as their JSON shapes — keep `T` JSON-safe if the manager might
+ * ever be pointed at a provider other than memory.
+ */
+export interface IdempotencyRecord<T> {
+  /**
+   * The record shape this was written with. A record written by a different version reads as a
+   * miss rather than as an error: with a day-long TTL, treating an unreadable record as a
+   * failure would turn one bad deploy into a day of failures.
+   */
+  version: number;
+  /** The lifecycle stage. */
+  state: RecordState;
+  /** When this revision of the record was written, ISO-8601. */
+  createdAt: string;
+  /** Identifies the request this key was used for, so a *different* request can be detected. */
+  fingerprint: string;
+  /**
+   * Identifies the execution that owns the claim. Only its owner may complete or release it,
+   * which is what stops an execution that outlived its claim from overwriting whoever
+   * re-claimed the key.
+   */
+  claimId: string;
+  /** The recorded result. Present only once `state` is `completed`. */
+  value?: T;
+}
+
+/**
+ * The outcome of {@link IdempotencyManager.run}.
+ *
+ * All four are expected control flow, not failures, so none of them throw — the divergence from
+ * the Go platform's error sentinels, and the same optional-over-sentinels stance the cache takes
+ * for a miss. Thrown {@link PlatformError}s are reserved for genuine failures (an unreachable
+ * record store, an unusable key).
+ */
+export type IdempotentResult<T> =
+  /** The work ran here, now. */
+  | { status: "executed"; value: T }
+  /** A recorded result was replayed instead of re-running the work. */
+  | { status: "replayed"; value: T }
+  /**
+   * The key names work that started elsewhere and has not reported back. Refused rather than
+   * re-run, because "did it happen?" is unanswerable and running it again is the worse guess.
+   */
+  | { status: "in-flight" }
+  /**
+   * The key was already used for a *different* request. Reported rather than answered with the
+   * earlier result, which would hide a client bug.
+   */
+  | { status: "fingerprint-mismatch" };
+
+/** Narrows the two outcomes that carry a value, for callers that treat replay as success. */
+export function hasValue<T>(
+  result: IdempotentResult<T>,
+): result is Extract<IdempotentResult<T>, { value: T }> {
+  return result.status === "executed" || result.status === "replayed";
+}

--- a/packages/idempotency/src/with-lock.node.test.ts
+++ b/packages/idempotency/src/with-lock.node.test.ts
@@ -1,0 +1,122 @@
+import { MemoryDistributedLock } from "@primandproper/distributedlock";
+import { describe, expect, it, vi } from "vitest";
+
+import { withLock } from "./with-lock.node.js";
+
+/** A controllable clock, so wait budgets are exercised without real time passing. */
+function fakeClock(start = 0): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+  };
+}
+
+describe("withLock", () => {
+  it("runs the callback while holding the lock and reports its value", async () => {
+    const lock = new MemoryDistributedLock();
+
+    const attempt = await withLock(lock, "k", async (held) => {
+      expect(held.key).toBe("k");
+      // Held for the duration of the callback: nobody else may take it.
+      await expect(lock.acquire("k")).resolves.toBeUndefined();
+      return "done";
+    });
+
+    expect(attempt).toEqual({ acquired: true, value: "done" });
+  });
+
+  it("releases the lock afterwards", async () => {
+    const lock = new MemoryDistributedLock();
+
+    await withLock(lock, "k", () => undefined);
+
+    await expect(lock.acquire("k")).resolves.toBeDefined();
+  });
+
+  it("releases the lock when the callback throws, and propagates the error", async () => {
+    const lock = new MemoryDistributedLock();
+
+    await expect(
+      withLock(lock, "k", () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    await expect(lock.acquire("k")).resolves.toBeDefined();
+  });
+
+  it("reports contention rather than throwing", async () => {
+    const lock = new MemoryDistributedLock();
+    await lock.acquire("k");
+
+    await expect(withLock(lock, "k", () => "unreachable")).resolves.toEqual({
+      acquired: false,
+    });
+  });
+
+  it("retries a held key until the wait budget is spent", async () => {
+    const lock = new MemoryDistributedLock();
+    await lock.acquire("k");
+    const clock = fakeClock();
+    const sleep = vi.fn(async (ms: number) => {
+      clock.advance(ms);
+    });
+
+    const attempt = await withLock(lock, "k", () => "unreachable", {
+      waitMs: 100,
+      pollMs: 25,
+      now: clock.now,
+      sleep,
+    });
+
+    expect(attempt).toEqual({ acquired: false });
+    // 4 sleeps of 25ms exhaust the 100ms budget; the 5th attempt finds the deadline reached.
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it("acquires on a later attempt when the holder releases", async () => {
+    const lock = new MemoryDistributedLock();
+    const held = await lock.acquire("k");
+    const clock = fakeClock();
+    let attempts = 0;
+    const sleep = async (ms: number): Promise<void> => {
+      clock.advance(ms);
+      attempts += 1;
+      if (attempts === 2) {
+        await held?.release();
+      }
+    };
+
+    await expect(
+      withLock(lock, "k", () => "done", {
+        waitMs: 1_000,
+        pollMs: 25,
+        now: clock.now,
+        sleep,
+      }),
+    ).resolves.toEqual({ acquired: true, value: "done" });
+  });
+
+  it("reports a failed release instead of masking the callback's result", async () => {
+    const lock = new MemoryDistributedLock();
+    const acquire = lock.acquire.bind(lock);
+    vi.spyOn(lock, "acquire").mockImplementation(async (key, opts) => {
+      const held = await acquire(key, opts);
+      return held === undefined
+        ? undefined
+        : {
+            ...held,
+            release: () => Promise.reject(new Error("store down")),
+          };
+    });
+    const onReleaseError = vi.fn();
+
+    await expect(withLock(lock, "k", () => "done", { onReleaseError })).resolves.toEqual({
+      acquired: true,
+      value: "done",
+    });
+    expect(onReleaseError).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/idempotency/src/with-lock.node.ts
+++ b/packages/idempotency/src/with-lock.node.ts
@@ -1,0 +1,76 @@
+import type { DistributedLock, Lock } from "@primandproper/distributedlock";
+
+/** The outcome of {@link withLock}: contention is reported, not thrown. */
+export type LockAttempt<R> =
+  | { acquired: true; value: R }
+  /** The key stayed held by someone else for the whole wait budget. */
+  | { acquired: false };
+
+/** Options for {@link withLock}. */
+export interface WithLockOptions {
+  /** Lease duration for the acquired lock, in milliseconds. */
+  ttlMs?: number;
+  /** How long to keep retrying a held key before giving up. `0` means a single attempt. */
+  waitMs?: number;
+  /** How long to wait between attempts. */
+  pollMs?: number;
+  /** Injectable clock, for deterministic tests. */
+  now?: () => number;
+  /** Injectable delay, for deterministic tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Called when releasing throws. Releasing happens in a `finally`, so letting it propagate
+   * would replace `fn`'s result — or `fn`'s own error — with a failure of the cleanup. The lease
+   * expires on its own ttl regardless, so the failure is reported here and otherwise ignored.
+   */
+  onReleaseError?: (err: unknown) => void;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Runs `fn` while holding `key`, releasing the lock afterwards even if `fn` throws.
+ *
+ * `DistributedLock.acquire` reports contention as `undefined` immediately rather than blocking,
+ * so this retries until `waitMs` is exhausted before reporting `{ acquired: false }`. Contention
+ * is a return value rather than an exception for the same reason the underlying `acquire` makes
+ * it one: it is an expected outcome the caller must branch on, not a failure.
+ *
+ * The release is best-effort — a `false` from `release()` means the lease had already expired or
+ * been taken over, which `fn` overrunning `ttlMs` would cause; keep `fn` short.
+ */
+export async function withLock<R>(
+  lock: DistributedLock,
+  key: string,
+  fn: (held: Lock) => Promise<R> | R,
+  options: WithLockOptions = {},
+): Promise<LockAttempt<R>> {
+  const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? defaultSleep;
+  const waitMs = options.waitMs ?? 0;
+  const pollMs = options.pollMs ?? 25;
+  const deadline = now() + waitMs;
+
+  for (;;) {
+    const held = await lock.acquire(
+      key,
+      options.ttlMs !== undefined ? { ttlMs: options.ttlMs } : {},
+    );
+    if (held !== undefined) {
+      try {
+        return { acquired: true, value: await fn(held) };
+      } finally {
+        try {
+          await held.release();
+        } catch (err) {
+          options.onReleaseError?.(err);
+        }
+      }
+    }
+    if (now() >= deadline) {
+      return { acquired: false };
+    }
+    await sleep(pollMs);
+  }
+}

--- a/packages/idempotency/tsconfig.json
+++ b/packages/idempotency/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/idempotency/tsup.config.ts
+++ b/packages/idempotency/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: { "index.node": "src/index.node.ts" },
+    platform: "node",
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+    clean: true,
+  },
+  {
+    entry: { "index.browser": "src/index.browser.ts" },
+    platform: "browser",
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+    clean: false,
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,18 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/authorization:
+    dependencies:
+      '@primandproper/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@primandproper/observability':
+        specifier: workspace:*
+        version: link:../observability
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/bitmask: {}
 
   packages/cache:
@@ -294,6 +306,30 @@ importers:
       '@primandproper/retry':
         specifier: workspace:*
         version: link:../retry
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
+  packages/idempotency:
+    dependencies:
+      '@primandproper/cache':
+        specifier: workspace:*
+        version: link:../cache
+      '@primandproper/cryptography':
+        specifier: workspace:*
+        version: link:../cryptography
+      '@primandproper/distributedlock':
+        specifier: workspace:*
+        version: link:../distributedlock
+      '@primandproper/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@primandproper/identifiers':
+        specifier: workspace:*
+        version: link:../identifiers
+      '@primandproper/observability':
+        specifier: workspace:*
+        version: link:../observability
       zod:
         specifier: 3.25.76
         version: 3.25.76


### PR DESCRIPTION
Closes #8.

Ports `platform-go/idempotency` as `@primandproper/idempotency`. The blocker (#6, per-entry cache TTL) landed in #15, so the manager can write a short-lived claim and a long-lived result through one store.

## The claim protocol

Copied rather than re-derived:

1. read the record — replay, refuse, or continue;
2. lock → **re-read** → write an in-flight claim → unlock;
3. run the work **outside** the lock;
4. record the result, or release the claim.

The re-read inside the lock is what makes it correct. The work stays outside the lock for the reasons `doc.go` gives that survive the port: a held lock is a held resource (the postgres provider holds a transaction), lock keys can collide, lock TTLs are shorter than real work, and a lock leaves no evidence when a process is killed mid-execution. Claims carry an owner id, so an execution that outlived its claim skips the write instead of handing the new owner a result from a different execution — counted by `idempotency.claims.lost`, which is the counter to alert on.

## TypeScript-specific calls

- **Outcomes are returned, not thrown.** `{ status: "executed" | "replayed" | "in-flight" | "fingerprint-mismatch" }` — expected control flow, matching the repo's optional-over-sentinels stance. Thrown `PlatformError`s (`idempotency/*`) are reserved for an unusable key, an empty fingerprint, and an unreachable store under fail-closed.
- **Isomorphic, asymmetric split.** `index.browser.ts` = key minting + fingerprints + `idempotentFetch`; `index.node.ts` = that plus the manager. A browser has no store or lock, and a noop stand-in would be idempotency that looks wired up and guarantees nothing. `idempotentFetch()` binds one key to the wrapper, so building it inside a retry loop is the visible mistake. ESLint bans the server-only packages from everything that is not `*.node.ts` in this package.
- **Canonicalisation.** `cryptography` has no canonical-hash helper, so `canonicalJson` (recursive key sort, array order preserved, `toJSON` honoured) plus length-prefixed part framing lives here, over `provideHashing`. A false mismatch is a rejected legitimate retry, hence sorting the query and canonicalising rather than hashing raw bytes.
- **Branded `IdempotencyKey`/`Fingerprint`.** `run` takes them adjacently; as bare strings a transposed pair type-checks and silently disables mismatch detection. Converted at the wire boundary by `parseIdempotencyKey`, which also validates (printable, space-free ASCII, length-capped).
- **Store-failure policy governs reads only**, matching platform-go exactly. A failed read can be treated as a miss and carried on from; a claim that could not be *written* leaves the completion nothing to prove ownership against, so a failed claim write or an unreachable locker refuses the request under either policy. The practical consequence — a wholly unreachable store refuses even under `fail-open`, since the claim cannot land either — is stated in the README rather than left to be discovered.
- **Record version stamped**; another version reads as a miss and re-runs rather than erroring, so one bad deploy is not a day of failures.
- **No latency histogram**: observability's `Observer.run` already records `operation.duration{operation="run"}`.

Also exports `withLock(lock, key, fn)` — the scoped acquire/run/release wrapper #8 asks for, reporting contention as `{ acquired: false }` rather than throwing, with a bounded wait because `acquire` reports contention immediately rather than blocking.

## Tests

73 tests. The suite covers every case the issue asks for: replay, concurrent claim, fingerprint mismatch (including mid-flight, which must beat `in-flight`), claim expiry then retry with the stale execution refusing to overwrite the new owner, store unavailable under both policies (a failed read failing open, and claim-write and locker failures refusing under either), the recordable predicate, unknown record versions and states, separate claim/result TTLs, and the per-call retention override. A fake store with an injectable clock drives expiry; the happy path also runs against the real memory cache and memory lock.

`format:check`, `lint`, `typecheck`, `test`, and `build` pass across the workspace. (`packages/authorization/` is unrelated pre-existing work-in-progress in the tree, not part of this branch.)

## Not ported

The transport adapters (`idempotency/http`, `idempotency/grpc`) — server middleware, response capture/replay, and the interceptors. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhrZu2juqReVTho9PWQ5e
