### PR TITLE
test(cache): de-flake the sweep-before-evict eviction test

### DIFF
--- a/.changeset/cache-eviction-test-flake.md
+++ b/.changeset/cache-eviction-test-flake.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: de-flake the `InMemoryCache` sweep-before-evict test. No shipped behaviour changes,
+so nothing to release.

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -143,12 +143,22 @@ describe("InMemoryCache eviction (CACHE-2)", () => {
   });
 
   it("sweeps expired entries before evicting live ones", async () => {
-    const cache = new InMemoryCache<number>({ maxEntries: 2, expiryMs: 1 });
-    await cache.set("a", 1);
-    await cache.set("b", 2);
-    await new Promise((r) => setTimeout(r, 5)); // let a and b expire
-    await cache.set("c", 3); // sweep reclaims a+b, no live eviction needed
-    expect(await cache.get("c")).toBe(3);
+    // Only the doomed entry carries a TTL, via the per-entry override; the cache itself has no
+    // configured expiry. A cache-wide `expiryMs: 1` would put the assertions on a 1ms fuse of
+    // their own — the entry under test could lapse between its write and its read on a loaded
+    // runner — and nothing about this behaviour needs the survivors to be perishable.
+    const cache = new InMemoryCache<number>({ maxEntries: 2 });
+    await cache.set("live", 1);
+    await cache.set("doomed", 2, { ttlMs: 1 });
+    await new Promise((r) => setTimeout(r, 5)); // let "doomed" lapse
+
+    await cache.set("fresh", 3); // at the cap: sweeping "doomed" makes room
+
+    // "live" is the load-bearing assertion. It is the oldest-inserted entry, so an eviction that
+    // did not sweep first would take it — sweeping is the only reason it survives.
+    expect(await cache.get("live")).toBe(1);
+    expect(await cache.get("fresh")).toBe(3);
+    expect(await cache.get("doomed")).toBeUndefined();
   });
 
   it("stays unbounded when maxEntries is 0", async () => {


### PR DESCRIPTION
`packages/cache/src/cache.test.ts` → "sweeps expired entries before evicting live ones" fails intermittently on unrelated PRs. It failed on #18's CI run, and reproduces roughly **1 run in 20** locally against unmodified provider code.

## Why it flakes

The cache was built with `expiryMs: 1`, and that default applies to *every* entry — including the one the assertion reads back:

```ts
const cache = new InMemoryCache<number>({ maxEntries: 2, expiryMs: 1 });
await cache.set("a", 1);
await cache.set("b", 2);
await new Promise((r) => setTimeout(r, 5)); // let a and b expire
await cache.set("c", 3);
expect(await cache.get("c")).toBe(3); // "c" is on a 1ms fuse of its own
```

`expiresAt` is `Date.now() + 1` and the read checks `expiresAt <= Date.now()`, so with millisecond clock granularity `"c"` is one tick from expired the moment it is written. Any scheduling hiccup between the write and the read — the likely state of a loaded CI runner — expires it.

## The fix

Only the entry that is *meant* to lapse carries a TTL, via the per-entry `ttlMs` override added in #15; the cache itself has no configured expiry, so the survivors cannot expire mid-assertion. Nothing about sweep-before-evict requires the survivors to be perishable.

The test also gains teeth it did not have. `"live"` is written **first**, so it is the oldest-inserted entry — an eviction that did not sweep first would take it. Asserting `"live"` survived is therefore a direct assertion that the sweep happened, rather than an inference from a bystander still being present.

Verified both directions:

- 10/10 green with the fix.
- Deleting the sweep loop from `InMemoryCache#evictIfNeeded` makes it fail — so it is a real regression test, not just a quieter one.

No shipped behaviour changes, hence an empty changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhrZu2juqReVTho9PWQ5e