### PR TITLE
feat(authorization): permission checks and static policy resolution

### DIFF
--- a/.changeset/authorization-core.md
+++ b/.changeset/authorization-core.md
@@ -1,0 +1,31 @@
+---
+"@primandproper/authorization": minor
+---
+
+Add `@primandproper/authorization` — the checking half of platform-go's `authorization`, plus
+static policy resolution.
+
+The design turns on one seam: resolving role names to permissions may do I/O and happens once per
+session; checking a permission is a map lookup and happens many times per request. Only resolution
+is pluggable, and **checking is synchronous, infallible, and allocation-free** — which is what
+keeps a check inside a loop from becoming N round trips, and what makes the same code usable in a
+React render. The browser therefore runs the identical checks the server does, so the permission
+set gating a handler and the one deciding which controls to draw cannot drift.
+
+There is deliberately no principal type: enforcement needs authority, not identity. Consumers
+bridge their own session with a `GrantsExtractor`, which is also where a multi-scope model
+collapses into "these sets, OR'd". Sets granting nothing are dropped, so an administrator acting
+on a tenant they do not belong to needs no branch anywhere, and an unpopulated `Grants` denies
+everything.
+
+`hasAll([])` is vacuously `true` — honest set algebra and a live hazard, since a requirement list
+that accidentally emptied would authorize everyone. The matrix of which declaration sites guard
+the empty case, and how, is documented in one place rather than scattered.
+
+`StaticPolicyResolver` expands role inheritance transitively, rejects a malformed policy at
+construction rather than applying it partially, and lets an unknown role contribute nothing rather
+than throwing — so a principal assigned a since-deleted role loses that authority, not the ability
+to make requests.
+
+Server enforcement middleware, a database-backed resolver, and a provider factory are not included
+yet; #9 stays open for them.

--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ logic, one build), **isomorphic** (same import resolves per-environment), **serv
 
 ### Isomorphic
 
-| Package                        | Purpose                                                                 |
-| ------------------------------ | ----------------------------------------------------------------------- |
-| `@primandproper/observability` | `Logger` (pino on Node, console in browser) + OTel tracer/meter aliases |
-| `@primandproper/cache`         | `Cache<T>` (memory/redis on Node, memory/web-storage in browser)        |
-| `@primandproper/cryptography`  | `Encryptor` + `Hasher` over WebCrypto                                   |
-| `@primandproper/random`        | Cryptographically secure random (hex, base32, base64url) over WebCrypto |
-| `@primandproper/compression`   | `Compressor` interface with swappable providers                         |
-| `@primandproper/cookies`       | `CookieStore` interface with swappable providers                        |
-| `@primandproper/httpclient`    | Thin `fetch` wrapper with OpenTelemetry spans                           |
-| `@primandproper/ratelimiting`  | `RateLimiter` interface with swappable providers                        |
-| `@primandproper/eventstream`   | `EventStream` over SSE and WebSocket                                    |
-| `@primandproper/analytics`     | `EventReporter` interface with swappable providers                      |
-| `@primandproper/eventcapture`  | Non-blocking high-volume event capture draining to a swappable sink     |
+| Package                        | Purpose                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------- |
+| `@primandproper/observability` | `Logger` (pino on Node, console in browser) + OTel tracer/meter aliases   |
+| `@primandproper/cache`         | `Cache<T>` (memory/redis on Node, memory/web-storage in browser)          |
+| `@primandproper/cryptography`  | `Encryptor` + `Hasher` over WebCrypto                                     |
+| `@primandproper/random`        | Cryptographically secure random (hex, base32, base64url) over WebCrypto   |
+| `@primandproper/compression`   | `Compressor` interface with swappable providers                           |
+| `@primandproper/cookies`       | `CookieStore` interface with swappable providers                          |
+| `@primandproper/httpclient`    | Thin `fetch` wrapper with OpenTelemetry spans                             |
+| `@primandproper/ratelimiting`  | `RateLimiter` interface with swappable providers                          |
+| `@primandproper/eventstream`   | `EventStream` over SSE and WebSocket                                      |
+| `@primandproper/analytics`     | `EventReporter` interface with swappable providers                        |
+| `@primandproper/eventcapture`  | Non-blocking high-volume event capture draining to a swappable sink       |
+| `@primandproper/authorization` | Synchronous permission checks everywhere, policy resolution on the server |
 
 ### Server-only
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,6 +80,17 @@ export default tseslint.config(
     },
   },
   {
+    // authorization is isomorphic and, unusually, every module in it is portable: the whole
+    // checking half ships to the browser, and even the static resolver runs without I/O. Only
+    // the split of what each entry point re-exports keeps resolution server-side, so the ban
+    // applies to the package as a whole rather than to a `*.node.ts` subset.
+    files: ["packages/authorization/src/**/*.ts"],
+    ignores: ["packages/authorization/src/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": ["error", nodeBuiltinBan],
+    },
+  },
+  {
     files: ["**/*.test.ts"],
     rules: {
       "@typescript-eslint/no-non-null-assertion": "off",

--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -1,0 +1,157 @@
+# @primandproper/authorization
+
+Answers "may this principal do this thing" — the TypeScript port of platform-go's
+`authorization`. `authentication` establishes _who_ is calling; this establishes _what they may
+do_.
+
+## The seam
+
+Two operations that look like one, and conflating them is the mistake the whole design exists to
+avoid:
+
+```
+resolve   role names -> permission set   once per session   may do I/O
+check     permission in set              many per request   never does
+```
+
+Only resolution is pluggable. **Checking is a map lookup: synchronous, infallible, allocation-free
+— and that it cannot fail is the property to defend.** The tempting interface —
+
+```ts
+authorize(principal, action, resource): Promise<boolean>
+```
+
+— makes a map lookup and a network round trip indistinguishable at the call site, which is how a
+permission check inside a loop becomes N round trips. It adds a rejection path with no cause, and
+the tempting way to handle "engine unavailable" is to allow. In TypeScript, synchronous also means
+usable directly in a React render, which is the point of the browser half: the same permission set
+that gates a handler decides which controls the UI draws, so the two cannot drift.
+
+## Checking
+
+```ts
+import { newGrants, newPermissionSet } from "@primandproper/authorization";
+
+const grants = newGrants(servicePermissions, accountPermissions);
+
+grants.has("recipes.create"); // boolean, right now
+grants.hasAny(["recipes.update", "recipes.delete"]);
+grants.evaluate(["recipes.create", "billing.refund"]); // { "recipes.create": true, ... }
+```
+
+`evaluate` returns an entry for **every** requested permission, including the `false` ones — a
+client distinguishing "denied" from "not asked" needs that to survive the round trip. It is the
+shape a "what can I do" endpoint hands a UI.
+
+## No principal type
+
+There is deliberately no `Principal` here: enforcement needs _authority_, not identity. Deriving
+authority from identity requires a store, which is exactly what drags I/O onto the check.
+Consumers bridge their own session type with a `GrantsExtractor`, and that adapter is also where a
+multi-scope model collapses:
+
+```ts
+const extract: GrantsExtractor<Ctx> = (ctx) => {
+  const session = ctx.get("session");
+  if (session === undefined) return undefined; // no authority determined -> denial
+  return newGrants(
+    session.servicePermissions, // may be undefined
+    session.accountPermissions[session.activeAccount], // absent key -> undefined
+  );
+};
+```
+
+Sets that grant nothing are **dropped**, so "an administrator acting on a tenant they do not
+belong to" carries one set instead of two and needs no branch anywhere. That case is the one most
+likely to be forgotten, so it is handled by construction rather than by remembering. An
+unpopulated `Grants` — `denyAll()` — denies everything, so a missing extractor or a failed
+authentication is safe by default rather than by vigilance.
+
+## The empty-list hazard
+
+`hasAll()` with **no** permissions is vacuously `true`. That is the honest answer for a universal
+quantifier, and it is a live hazard: a requirement list that accidentally resolved to zero
+permissions would authorize everyone. The set algebra stays honest and each declaration site
+guards, which means the sites answer the empty case differently **on purpose**:
+
+| site                                         | empty list                                    |
+| -------------------------------------------- | --------------------------------------------- |
+| `PermissionSet.hasAll()` / `Grants.hasAll()` | `true` — set algebra                          |
+| server enforcement middleware                | denies — far more likely a bug than an intent |
+| a frozen requirements table                  | refuses to build at all                       |
+
+"Empty means allow" is therefore only ever safe with a list you wrote **literally**. Anything
+derived from configuration, a database, or a lookup must be checked for emptiness first. The last
+two rows describe the enforcement layer, which is not ported yet — see "Not ported" below — so
+today that check is the caller's job.
+
+## Policy resolution (server only)
+
+A `Role` grants permissions and may inherit from other roles, transitively. `StaticPolicyResolver`
+is the default and the one to reach for until something forces otherwise: no database, no
+migrations, no configuration, and it resolves without I/O.
+
+```ts
+import { StaticPolicyResolver } from "@primandproper/authorization";
+
+const resolver = new StaticPolicyResolver([
+  { name: "reader", permissions: ["recipes.read"] },
+  { name: "author", permissions: ["recipes.create"], inherits: ["reader"] },
+]);
+
+const permissions = await resolver.permissionsForRoles(session.roles); // once, per session
+```
+
+Graduate to a stored policy only when roles themselves must become editable data — when an
+operator has to define a role, or change what one grants, without shipping a release. Reassigning
+_which_ roles a principal holds does not require it: assignments reference the consumer's own
+users and tenants, so they belong to the consumer. **This package owns policy, not assignment.**
+
+Two rules the resolvers share, so backends stay interchangeable:
+
+- **Malformed policy is rejected, never partially applied.** `validateRoles` catches an unnamed
+  role, a duplicate, an undefined parent, self-inheritance, and inheritance cycles; the static
+  resolver runs it at construction, so a policy mistake fails at startup rather than as a puzzling
+  denial later. A policy with more than one cycle names the same one every run.
+- **An unknown role contributes nothing rather than throwing.** A principal still assigned a role
+  the policy has since dropped loses that authority, not the ability to make requests. Use
+  `roles()` to detect that deliberately.
+
+`expandInheritance` is the reference semantics: any backend that expands some other way (in SQL,
+say) owes a test asserting it agrees with this function.
+
+## The isomorphic split
+
+- `index.browser.ts` — permission sets, grants, and errors: the checking half.
+- `index.node.ts` — the same, plus policy resolution.
+
+Resolution is absent from the browser rather than stubbed. It may do I/O and belongs to the
+server, which hands the browser the resolved set; a browser that could resolve policy would be a
+browser that _holds_ policy. `grantsFromJSON` is the hydration seam, and it is deliberately
+tolerant: a payload whose shape drifted costs its holder authority rather than throwing mid-render.
+
+## Turning it off
+
+`allowAll()` is the escape hatch, and it is deliberately a function call at a call site rather
+than a configuration flag: turning authorization off should be visible in a diff, not reachable by
+setting an environment variable in production.
+
+## Errors
+
+`PermissionDeniedError` says exactly `"permission denied"` and nothing else. Which permission was
+missing goes to `missing`, and from there to a span or a log, and stops there — naming it in a
+response discloses the permission taxonomy to a caller who just failed to authorize. Serialize
+`message` and nothing more. Wrapping with `@primandproper/errors`' `wrap` preserves the code, so
+adding context at a boundary does not turn a denial into a 500.
+
+## Not ported
+
+- **Server enforcement** — the middleware that denies an empty requirement list, and the frozen
+  requirements table that refuses to build one. TypeScript has a real opportunity here that Go
+  lacked: with hono/express/fastify the route table is enumerable at startup, so a boot-time check
+  that every registered route either declares permissions or is explicitly marked public is
+  achievable.
+- **A database-backed resolver**, and the cached-resolver wrapper `PolicyInvalidator` exists for.
+- **A `config.ts` provider factory** — resolvers are constructed directly for now.
+
+Tracked in [#9](https://github.com/primandproper/platform-ts/issues/9).

--- a/packages/authorization/package.json
+++ b/packages/authorization/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@primandproper/authorization",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Isomorphic authorization: synchronous permission checks everywhere, pluggable policy resolution on the server.",
+  "license": "AGPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/primandproper/platform-ts.git",
+    "directory": "packages/authorization"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./dist/index.browser.d.ts",
+        "default": "./dist/index.browser.js"
+      },
+      "node": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      },
+      "default": {
+        "types": "./dist/index.node.d.ts",
+        "default": "./dist/index.node.js"
+      }
+    }
+  },
+  "types": "./dist/index.node.d.ts",
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint .",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@primandproper/errors": "workspace:*",
+    "@primandproper/observability": "workspace:*",
+    "zod": "3.25.76"
+  }
+}

--- a/packages/authorization/src/errors.test.ts
+++ b/packages/authorization/src/errors.test.ts
@@ -1,0 +1,84 @@
+import { isPlatformError, wrap } from "@primandproper/errors";
+import { describe, expect, it } from "vitest";
+
+import {
+  InvalidPolicyError,
+  isInvalidPolicy,
+  isPermissionDenied,
+  PermissionDeniedError,
+  PERMISSION_DENIED_CODE,
+  POLICY_INVALID_CODE,
+} from "./errors.js";
+
+describe("PermissionDeniedError", () => {
+  it("says only 'permission denied', whatever was missing", () => {
+    // Naming the permission in a response discloses the taxonomy to a caller who just failed to
+    // authorize, so the message is a constant and the detail rides alongside.
+    const err = new PermissionDeniedError(["billing.refund"]);
+    expect(err.message).toBe("permission denied");
+    expect(err.message).not.toContain("billing.refund");
+    expect(err.missing).toEqual(["billing.refund"]);
+  });
+
+  it("carries the shared code and is recognised by the guard", () => {
+    const err = new PermissionDeniedError();
+    expect(err.code).toBe(PERMISSION_DENIED_CODE);
+    expect(isPermissionDenied(err)).toBe(true);
+    expect(isPlatformError(err, PERMISSION_DENIED_CODE)).toBe(true);
+  });
+
+  it("defaults to no missing permissions and copies the list it is given", () => {
+    expect(new PermissionDeniedError().missing).toEqual([]);
+
+    const missing = ["a"];
+    const err = new PermissionDeniedError(missing);
+    missing.push("b");
+    expect(err.missing).toEqual(["a"]);
+  });
+
+  it("is still recognised once wrapped for context", () => {
+    // `wrap` re-raises a PlatformError under the same code, so adding context at a boundary does
+    // not turn a denial into a 500. The `missing` list does not survive the wrap — it lives on
+    // the original, reachable through `cause`.
+    const original = new PermissionDeniedError(["users.delete"]);
+    const wrapped = wrap("deleting user", original);
+
+    expect(isPermissionDenied(wrapped)).toBe(true);
+    expect(wrapped.message).toBe("deleting user: permission denied");
+    expect(wrapped).not.toBeInstanceOf(PermissionDeniedError);
+    expect((wrapped.cause as PermissionDeniedError).missing).toEqual(["users.delete"]);
+  });
+
+  it("keeps a cause when given one", () => {
+    const cause = new Error("upstream");
+    expect(new PermissionDeniedError([], { cause }).cause).toBe(cause);
+  });
+
+  it("is not confused for a policy error", () => {
+    expect(isInvalidPolicy(new PermissionDeniedError())).toBe(false);
+  });
+});
+
+describe("InvalidPolicyError", () => {
+  it("codes the specific problem under the shared prefix", () => {
+    const err = new InvalidPolicyError("duplicate-role", "duplicate role name: reader");
+    expect(err.code).toBe(`${POLICY_INVALID_CODE}/duplicate-role`);
+    expect(err.problem).toBe("duplicate-role");
+    expect(err.message).toBe("duplicate role name: reader");
+  });
+
+  it("is matched by the guard, with or without a specific problem", () => {
+    const err = new InvalidPolicyError("inheritance-cycle", "a -> b -> a");
+    expect(isInvalidPolicy(err)).toBe(true);
+    expect(isInvalidPolicy(err, "inheritance-cycle")).toBe(true);
+    expect(isInvalidPolicy(err, "duplicate-role")).toBe(false);
+  });
+
+  it("does not match a non-platform error or an unrelated one", () => {
+    expect(isInvalidPolicy(new Error("nope"))).toBe(false);
+    expect(isInvalidPolicy(undefined)).toBe(false);
+    expect(isPermissionDenied(new InvalidPolicyError("empty-role-name", "x"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/authorization/src/errors.ts
+++ b/packages/authorization/src/errors.ts
@@ -1,0 +1,66 @@
+import { isPlatformError, PlatformError } from "@primandproper/errors";
+
+/** The `code` every {@link PermissionDeniedError} carries. */
+export const PERMISSION_DENIED_CODE = "authorization/permission-denied";
+
+/** The `code` prefix shared by every malformed-policy error. */
+export const POLICY_INVALID_CODE = "authorization/policy-invalid";
+
+/**
+ * The requester lacks the authority to perform the action.
+ *
+ * The message a client sees is the constant `"permission denied"`. Which permission was missing
+ * goes to `missing`, and from there to the span and the log, and stops there — naming it in a
+ * response discloses the permission taxonomy to a caller who just failed to authorize. Anything
+ * that serializes this error to a client should send `message` and nothing else.
+ */
+export class PermissionDeniedError extends PlatformError {
+  /** The permissions the principal did not hold. Diagnostic only — never put this in a response body. */
+  readonly missing: readonly string[];
+
+  constructor(missing: readonly string[] = [], options?: ErrorOptions) {
+    super(PERMISSION_DENIED_CODE, "permission denied", options);
+    this.name = "PermissionDeniedError";
+    this.missing = [...missing];
+  }
+}
+
+/** True when `err` is a {@link PermissionDeniedError}, including one wrapped by `@primandproper/errors`. */
+export function isPermissionDenied(err: unknown): boolean {
+  return isPlatformError(err, PERMISSION_DENIED_CODE);
+}
+
+/** Why a policy was rejected. Each value is also the suffix of the thrown error's `code`. */
+export type PolicyProblem =
+  | "empty-role-name"
+  | "duplicate-role"
+  | "unknown-parent-role"
+  | "self-inheritance"
+  | "inheritance-cycle";
+
+/**
+ * A policy is malformed and was rejected rather than partially applied.
+ *
+ * Both the validator and every resolver throw this, so a policy rejected in one backend is
+ * rejected in the others — a code-side policy cannot quietly drift from a stored one.
+ */
+export class InvalidPolicyError extends PlatformError {
+  /** Which rule the policy broke, for callers that branch rather than just report. */
+  readonly problem: PolicyProblem;
+
+  constructor(problem: PolicyProblem, message: string, options?: ErrorOptions) {
+    super(`${POLICY_INVALID_CODE}/${problem}`, message, options);
+    this.name = "InvalidPolicyError";
+    this.problem = problem;
+  }
+}
+
+/** True when `err` is an {@link InvalidPolicyError}; narrows to a specific `problem` when given. */
+export function isInvalidPolicy(err: unknown, problem?: PolicyProblem): boolean {
+  if (!isPlatformError(err)) {
+    return false;
+  }
+  return problem === undefined
+    ? err.code.startsWith(`${POLICY_INVALID_CODE}/`)
+    : err.code === `${POLICY_INVALID_CODE}/${problem}`;
+}

--- a/packages/authorization/src/grants.test.ts
+++ b/packages/authorization/src/grants.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  allowAll,
+  denyAll,
+  grantsFromJSON,
+  newGrants,
+  type GrantsExtractor,
+} from "./grants.js";
+import { emptyPermissionSet, newPermissionSet } from "./permission.js";
+
+const service = newPermissionSet("service.admin");
+const account = newPermissionSet("recipes.create", "recipes.read");
+
+describe("Grants", () => {
+  it("ORs the sets it was given", () => {
+    const grants = newGrants(service, account);
+    expect(grants.has("service.admin")).toBe(true);
+    expect(grants.has("recipes.create")).toBe(true);
+    expect(grants.has("nothing.here")).toBe(false);
+  });
+
+  it("denies everything when unpopulated", () => {
+    expect(denyAll().isEmpty()).toBe(true);
+    expect(denyAll().has("anything")).toBe(false);
+    expect(newGrants().has("anything")).toBe(false);
+  });
+
+  it("drops sets that grant nothing, so the awkward case needs no branch", () => {
+    // "Administrator acting on a tenant they are not a member of" arrives as one set, not two.
+    const grants = newGrants(service, emptyPermissionSet, undefined);
+    expect(grants.has("service.admin")).toBe(true);
+    expect(grants.isEmpty()).toBe(false);
+
+    expect(newGrants(emptyPermissionSet, undefined).isEmpty()).toBe(true);
+  });
+
+  it("allows everything under allowAll, and says so", () => {
+    const grants = allowAll();
+    expect(grants.has("anything.at.all")).toBe(true);
+    expect(grants.hasAll(["a", "b"])).toBe(true);
+    expect(grants.isAllowAll()).toBe(true);
+    expect(grants.isEmpty()).toBe(false);
+    expect(denyAll().isAllowAll()).toBe(false);
+  });
+
+  it("is vacuously true for hasAll with no permissions — the documented hazard", () => {
+    expect(denyAll().hasAll([])).toBe(true);
+  });
+
+  it("requires every permission for hasAll and any one for hasAny", () => {
+    const grants = newGrants(account);
+    expect(grants.hasAll(["recipes.create", "recipes.read"])).toBe(true);
+    expect(grants.hasAll(["recipes.create", "recipes.delete"])).toBe(false);
+    expect(grants.hasAny(["recipes.delete", "recipes.read"])).toBe(true);
+    expect(grants.hasAny(["recipes.delete"])).toBe(false);
+  });
+
+  it("evaluates every requested permission, including the denials", () => {
+    // A client distinguishing "denied" from "not asked" needs the false entries to survive.
+    expect(newGrants(account).evaluate(["recipes.read", "recipes.delete"])).toEqual({
+      "recipes.read": true,
+      "recipes.delete": false,
+    });
+  });
+
+  it("evaluates to an empty record when asked about nothing", () => {
+    expect(newGrants(account).evaluate([])).toEqual({});
+  });
+
+  it("reports what is missing, in the order asked", () => {
+    expect(
+      newGrants(account).missing(["recipes.delete", "recipes.read", "billing"]),
+    ).toEqual(["recipes.delete", "billing"]);
+    expect(newGrants(account).missing(["recipes.read"])).toEqual([]);
+  });
+});
+
+describe("GrantsExtractor", () => {
+  it("bridges a consumer session, collapsing scopes into one OR'd authority", () => {
+    interface Session {
+      servicePermissions?: ReturnType<typeof newPermissionSet>;
+      accountPermissions: Record<string, ReturnType<typeof newPermissionSet>>;
+      activeAccount: string;
+    }
+    const extract: GrantsExtractor<Session | undefined> = (session) => {
+      if (session === undefined) {
+        return undefined;
+      }
+      return newGrants(
+        session.servicePermissions,
+        session.accountPermissions[session.activeAccount],
+      );
+    };
+
+    const grants = extract({
+      accountPermissions: { acct_1: account },
+      activeAccount: "acct_1",
+    });
+    expect(grants?.has("recipes.create")).toBe(true);
+
+    // An account the principal is not a member of: an absent key, not a special case.
+    const outsider = extract({
+      servicePermissions: service,
+      accountPermissions: { acct_1: account },
+      activeAccount: "acct_2",
+    });
+    expect(outsider?.has("service.admin")).toBe(true);
+    expect(outsider?.has("recipes.create")).toBe(false);
+
+    // No authority could be determined — a denial, and never an error.
+    expect(extract(undefined)).toBeUndefined();
+  });
+});
+
+describe("grantsFromJSON", () => {
+  it("hydrates every scope a session carries", () => {
+    const grants = grantsFromJSON(["service.admin"], ["recipes.create"]);
+    expect(grants.has("service.admin")).toBe(true);
+    expect(grants.has("recipes.create")).toBe(true);
+  });
+
+  it("costs a malformed payload its authority rather than throwing", () => {
+    expect(grantsFromJSON(undefined, "not-an-array", { nope: true }).isEmpty()).toBe(
+      true,
+    );
+  });
+
+  it("survives a partially malformed payload with the readable scopes intact", () => {
+    const grants = grantsFromJSON(["service.admin"], null);
+    expect(grants.has("service.admin")).toBe(true);
+  });
+});

--- a/packages/authorization/src/grants.ts
+++ b/packages/authorization/src/grants.ts
@@ -1,0 +1,172 @@
+import { PermissionSet, permissionSetFromJSON, type Permission } from "./permission.js";
+
+/**
+ * A principal's effective authority for a single request: one or more granted permission sets,
+ * OR'd together.
+ *
+ * It holds an array of sets rather than a materialized union deliberately. Merging a service-wide
+ * set and an account-scoped set of a few hundred permissions each would allocate a set of their
+ * combined size on every request; OR-ing at lookup allocates nothing.
+ *
+ * {@link denyAll} — which is what an unpopulated `Grants` is — denies everything, so a missing
+ * extractor, a failed authentication, or a field nobody set is safe by construction rather than by
+ * remembering to check.
+ */
+export class Grants {
+  readonly #sets: readonly PermissionSet[];
+  readonly #all: boolean;
+
+  /** @internal Use {@link newGrants}, {@link allowAll}, or {@link denyAll}. */
+  private constructor(sets: readonly PermissionSet[], all: boolean) {
+    this.#sets = sets;
+    this.#all = all;
+  }
+
+  /** @internal */
+  static build(sets: readonly PermissionSet[], all: boolean): Grants {
+    return new Grants(sets, all);
+  }
+
+  /** Reports whether any of the granted sets contains `perm`. */
+  has(perm: Permission): boolean {
+    if (this.#all) {
+      return true;
+    }
+    for (const set of this.#sets) {
+      if (set.has(perm)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reports whether every permission in `perms` is granted.
+   *
+   * Calling it with no permissions is vacuously `true`, so a list that reached zero length by
+   * accident authorizes everyone. {@link PermissionSet.hasAll} carries the full matrix of which
+   * declaration sites guard the empty case and how — read it before calling this from anything
+   * that decides access. Code deciding access from a *derived* list must reject the empty case
+   * itself before calling this, since the enforcement layer that would otherwise do it is not
+   * ported yet.
+   */
+  hasAll(perms: Iterable<Permission>): boolean {
+    for (const p of perms) {
+      if (!this.has(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Reports whether any permission in `perms` is granted. */
+  hasAny(perms: Iterable<Permission>): boolean {
+    for (const p of perms) {
+      if (this.has(p)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reports the outcome for each permission in `perms`.
+   *
+   * This is the shape a "what can I do" endpoint needs in order to tell a client which controls to
+   * render. The returned record always has an entry for every requested permission, **including
+   * the `false` ones** — a caller distinguishing "denied" from "not asked" needs that distinction
+   * to survive the round trip.
+   */
+  evaluate(perms: Iterable<Permission>): Record<Permission, boolean> {
+    const out: Record<Permission, boolean> = {};
+    for (const p of perms) {
+      out[p] = this.has(p);
+    }
+    return out;
+  }
+
+  /** The permissions missing from `perms`, in the order given. Empty when {@link hasAll} would be `true`. */
+  missing(perms: Iterable<Permission>): Permission[] {
+    const out: Permission[] = [];
+    for (const p of perms) {
+      if (!this.has(p)) {
+        out.push(p);
+      }
+    }
+    return out;
+  }
+
+  /** Reports whether these grants permit nothing at all. */
+  isEmpty(): boolean {
+    return !this.#all && this.#sets.length === 0;
+  }
+
+  /** Reports whether these grants came from {@link allowAll}. Enforcement logs it; nothing else should branch on it. */
+  isAllowAll(): boolean {
+    return this.#all;
+  }
+}
+
+/**
+ * Builds {@link Grants} from one or more permission sets. Sets that grant nothing are dropped.
+ *
+ * Dropping them is what makes the awkward case structural rather than conditional: a service
+ * administrator acting on a tenant they are not a member of simply carries one set instead of two.
+ * Callers do not check for it, and cannot forget to. That case is the one most likely to be
+ * forgotten, which is why it is handled by construction here rather than by a branch out there.
+ */
+export function newGrants(...sets: readonly (PermissionSet | undefined)[]): Grants {
+  const kept = sets.filter((s): s is PermissionSet => s !== undefined && !s.isEmpty());
+  return Grants.build(kept, false);
+}
+
+/**
+ * Grants that permit everything.
+ *
+ * It exists for tests and local development, and it is deliberately a function call at a call site
+ * rather than a configurable provider: turning authorization off should be visible in a diff, not
+ * reachable by setting an environment variable in production.
+ */
+export function allowAll(): Grants {
+  return Grants.build([], true);
+}
+
+/** Grants that permit nothing. The default, named. */
+export function denyAll(): Grants {
+  return Grants.build([], false);
+}
+
+/**
+ * Pulls a principal's authority out of whatever a consumer's request context happens to be.
+ *
+ * It is a function rather than an interface so this package never needs to know how a consumer
+ * represents a session. The consumer writes the adapter over whatever its authentication layer
+ * produced, and that adapter is where a multi-scope model collapses into the flat "these sets,
+ * OR'd" this package understands:
+ *
+ * ```ts
+ * const extract: GrantsExtractor<Ctx> = (ctx) => {
+ *   const session = ctx.get("session");
+ *   if (session === undefined) return undefined;
+ *   return newGrants(
+ *     session.servicePermissions,                        // may be undefined
+ *     session.accountPermissions[session.activeAccount],  // absent key -> undefined
+ *   );
+ * };
+ * ```
+ *
+ * Returning `undefined` means "no authority could be determined", which every enforcement path
+ * treats as a denial — not as an error, and never as a pass.
+ */
+export type GrantsExtractor<Ctx> = (ctx: Ctx) => Grants | undefined;
+
+/**
+ * Hydrates {@link Grants} from decoded session JSON — the browser's entry point into this package.
+ *
+ * Each value is passed through {@link permissionSetFromJSON}, so a payload whose shape drifted
+ * costs its holder authority rather than throwing mid-render. Pass every scope the session carries;
+ * the ones that grant nothing drop out.
+ */
+export function grantsFromJSON(...values: readonly unknown[]): Grants {
+  return newGrants(...values.map(permissionSetFromJSON));
+}

--- a/packages/authorization/src/index.browser.ts
+++ b/packages/authorization/src/index.browser.ts
@@ -1,0 +1,16 @@
+/**
+ * Browser entry: the checking half — permission sets, grants, and the errors they raise.
+ *
+ * This is the half that decides which controls a UI renders, and it is deliberately the *same*
+ * code the server checks with, so the two cannot drift. A session payload hydrates it directly
+ * through {@link grantsFromJSON}; every check is synchronous, so it is usable in a render path
+ * without a suspense boundary or a loading state.
+ *
+ * Policy resolution is absent here rather than stubbed: resolving role names to permissions may
+ * do I/O and belongs to the server, which then hands the browser the resolved set. Reaching for
+ * `StaticPolicyResolver` in browser-resolved code is a type error, which is the intended
+ * feedback — a browser that could resolve policy would be a browser that holds it.
+ */
+export * from "./errors.js";
+export * from "./grants.js";
+export * from "./permission.js";

--- a/packages/authorization/src/index.node.ts
+++ b/packages/authorization/src/index.node.ts
@@ -1,0 +1,13 @@
+/**
+ * Node entry: the checking half the browser also gets, plus policy resolution.
+ *
+ * The asymmetry is the design. Checking is synchronous, infallible, and identical on both sides;
+ * resolving role names to permissions may touch a database and stays on the server. A caller
+ * resolves once when it builds a session and checks many times per request against the resulting
+ * {@link Grants}.
+ */
+export * from "./errors.js";
+export * from "./grants.js";
+export * from "./permission.js";
+export * from "./policy.js";
+export { StaticPolicyResolver } from "./providers/static.js";

--- a/packages/authorization/src/permission.test.ts
+++ b/packages/authorization/src/permission.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emptyPermissionSet,
+  newPermissionSet,
+  PermissionSet,
+  permissionSetFromJSON,
+} from "./permission.js";
+
+describe("PermissionSet", () => {
+  it("holds the permissions it was built with", () => {
+    const set = newPermissionSet("read", "write");
+    expect(set.has("read")).toBe(true);
+    expect(set.has("write")).toBe(true);
+    expect(set.has("delete")).toBe(false);
+    expect(set.size).toBe(2);
+  });
+
+  it("collapses duplicates and drops empty strings", () => {
+    const set = new PermissionSet(["read", "read", "", "write"]);
+    expect(set.size).toBe(2);
+    // An empty permission can never be held, so an empty check can never accidentally pass.
+    expect(set.has("")).toBe(false);
+  });
+
+  it("copies its input, so a later mutation cannot edit the set", () => {
+    const source = ["read"];
+    const set = new PermissionSet(source);
+    source.push("write");
+    expect(set.has("write")).toBe(false);
+  });
+
+  it("grants nothing when empty", () => {
+    expect(emptyPermissionSet.isEmpty()).toBe(true);
+    expect(emptyPermissionSet.has("read")).toBe(false);
+    expect(emptyPermissionSet.size).toBe(0);
+  });
+
+  it("is vacuously true for hasAll with no permissions — the documented hazard", () => {
+    // Set algebra's honest answer, and the reason a derived requirement list must be checked for
+    // emptiness before it reaches here.
+    expect(emptyPermissionSet.hasAll([])).toBe(true);
+    expect(newPermissionSet("read").hasAll([])).toBe(true);
+  });
+
+  it("is false for hasAny with no permissions — there is no witness", () => {
+    expect(newPermissionSet("read").hasAny([])).toBe(false);
+  });
+
+  it("requires every permission for hasAll and any one for hasAny", () => {
+    const set = newPermissionSet("read", "write");
+    expect(set.hasAll(["read", "write"])).toBe(true);
+    expect(set.hasAll(["read", "delete"])).toBe(false);
+    expect(set.hasAny(["delete", "write"])).toBe(true);
+    expect(set.hasAny(["delete"])).toBe(false);
+  });
+
+  it("orders values deterministically, so serialized forms are stable", () => {
+    expect(newPermissionSet("write", "admin", "read").values()).toEqual([
+      "admin",
+      "read",
+      "write",
+    ]);
+    expect([...newPermissionSet("b", "a")]).toEqual(["a", "b"]);
+  });
+
+  it("unions without mutating either operand", () => {
+    const a = newPermissionSet("read");
+    const b = newPermissionSet("write");
+
+    const union = a.union(b);
+
+    expect(union.values()).toEqual(["read", "write"]);
+    expect(a.size).toBe(1);
+    expect(b.size).toBe(1);
+  });
+
+  it("unions several sets at once", () => {
+    expect(
+      newPermissionSet("a").union(newPermissionSet("b"), newPermissionSet("c")).values(),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("treats the empty set as a subset of everything", () => {
+    expect(emptyPermissionSet.isSubsetOf(newPermissionSet("read"))).toBe(true);
+    expect(newPermissionSet("read").isSubsetOf(emptyPermissionSet)).toBe(false);
+  });
+
+  it("compares by contents, not identity", () => {
+    expect(newPermissionSet("a", "b").equals(newPermissionSet("b", "a"))).toBe(true);
+    expect(newPermissionSet("a").equals(newPermissionSet("a", "b"))).toBe(false);
+  });
+
+  it("summarises rather than lists in toString, so telemetry cannot leak the taxonomy", () => {
+    const set = newPermissionSet("billing.refund", "users.delete");
+    expect(set.toString()).toBe("PermissionSet(n=2)");
+    expect(set.toString()).not.toContain("billing.refund");
+  });
+});
+
+describe("PermissionSet JSON round trip", () => {
+  it("encodes as a sorted array through JSON.stringify", () => {
+    expect(JSON.stringify(newPermissionSet("write", "read"))).toBe('["read","write"]');
+  });
+
+  it("hydrates back to an equal set", () => {
+    const original = newPermissionSet("read", "write");
+    const hydrated = permissionSetFromJSON(JSON.parse(JSON.stringify(original)));
+    expect(hydrated.equals(original)).toBe(true);
+  });
+
+  it("costs a malformed payload its authority rather than throwing", () => {
+    // Failing closed matters more than failing loudly here: throwing inside a render is the
+    // worst available outcome, and an unreadable payload should grant nothing.
+    for (const malformed of [undefined, null, 42, "read", { read: true }]) {
+      expect(permissionSetFromJSON(malformed).isEmpty()).toBe(true);
+    }
+  });
+
+  it("keeps the string entries of a mixed array and drops the rest", () => {
+    expect(permissionSetFromJSON(["read", 7, null, "write"]).values()).toEqual([
+      "read",
+      "write",
+    ]);
+  });
+});

--- a/packages/authorization/src/permission.ts
+++ b/packages/authorization/src/permission.ts
@@ -1,0 +1,178 @@
+/**
+ * Names an action a principal may be authorized to perform.
+ *
+ * It is a bare string so consumers declare their own vocabulary as ordinary constants:
+ *
+ * ```ts
+ * export const CreateRecipes: Permission = "create.recipes";
+ * ```
+ *
+ * A consumer with an existing permission union adopts this one with a type alias
+ * (`type Permission = import("@primandproper/authorization").Permission`), which leaves every
+ * existing constant, object key, and `switch` compiling unchanged.
+ */
+export type Permission = string;
+
+/**
+ * An immutable set of permissions.
+ *
+ * Every check is synchronous, allocation-free, and cannot fail — see the package README for why
+ * that is the property the whole design exists to protect. An empty set grants nothing, which is
+ * load-bearing rather than defensive: a principal with no membership in some scope is represented
+ * by an empty set rather than an absent entry, so "no grants here" needs no special case at any
+ * call site.
+ */
+export class PermissionSet {
+  readonly #perms: ReadonlySet<Permission>;
+
+  /**
+   * Builds a set containing `perms`. Duplicates collapse and empty strings are dropped. The set
+   * copies its input, so mutating the caller's array afterwards cannot change it.
+   */
+  constructor(perms: Iterable<Permission> = []) {
+    const set = new Set<Permission>();
+    for (const p of perms) {
+      if (p !== "") {
+        set.add(p);
+      }
+    }
+    this.#perms = set;
+  }
+
+  /** Reports whether `perm` is in the set. */
+  has(perm: Permission): boolean {
+    return perm !== "" && this.#perms.has(perm);
+  }
+
+  /**
+   * Reports whether every permission in `perms` is in the set.
+   *
+   * **`hasAll()` with no permissions is vacuously `true`.** That is the mathematically honest
+   * answer for a universal quantifier, and it is a live hazard: a requirement list that
+   * accidentally resolved to zero permissions would authorize everyone. Set algebra wins here and
+   * the guard belongs at each declaration site, so the three places a permission list is declared
+   * answer the empty case differently on purpose:
+   *
+   * | site | empty list |
+   * | --- | --- |
+   * | `PermissionSet.hasAll()` / `Grants.hasAll()` | `true` — set algebra |
+   * | server enforcement middleware | denies — an empty list is far more likely a bug |
+   * | a frozen requirements table | refuses to build at all |
+   *
+   * "Empty means allow" is therefore only ever safe with a list you wrote literally. Anything
+   * derived from configuration, a database, or a lookup must be checked for emptiness before it
+   * reaches here.
+   *
+   * **The last two rows describe an enforcement layer this package does not ship yet** — see
+   * "Not ported" in the README. Until it lands, guarding a derived list is the caller's job, and
+   * this is the hazard to guard against.
+   */
+  hasAll(perms: Iterable<Permission>): boolean {
+    for (const p of perms) {
+      if (!this.has(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Reports whether any permission in `perms` is in the set. With no permissions: `false` — there is no witness. */
+  hasAny(perms: Iterable<Permission>): boolean {
+    for (const p of perms) {
+      if (this.has(p)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** The number of permissions in the set. */
+  get size(): number {
+    return this.#perms.size;
+  }
+
+  /** Reports whether the set grants nothing. */
+  isEmpty(): boolean {
+    return this.#perms.size === 0;
+  }
+
+  /**
+   * The set's permissions in sorted order. The order is deterministic so that encodings, golden
+   * files, and equality checks over serialized forms are stable across runs.
+   */
+  values(): Permission[] {
+    return [...this.#perms].sort();
+  }
+
+  /** Iterates the set in sorted order. */
+  [Symbol.iterator](): IterableIterator<Permission> {
+    return this.values()[Symbol.iterator]();
+  }
+
+  /** A new set containing everything in this set and in `others`. */
+  union(...others: readonly PermissionSet[]): PermissionSet {
+    const merged = new Set(this.#perms);
+    for (const other of others) {
+      for (const p of other.#perms) {
+        merged.add(p);
+      }
+    }
+    return new PermissionSet(merged);
+  }
+
+  /** Reports whether every permission in this set is also in `other`. The empty set is a subset of everything. */
+  isSubsetOf(other: PermissionSet): boolean {
+    for (const p of this.#perms) {
+      if (!other.has(p)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Reports whether this set and `other` contain exactly the same permissions. */
+  equals(other: PermissionSet): boolean {
+    return this.size === other.size && this.isSubsetOf(other);
+  }
+
+  /**
+   * Encodes the set as a sorted array of strings — the wire form a server hands a browser so a
+   * session payload can hydrate one directly. `JSON.stringify(set)` picks this up automatically.
+   */
+  toJSON(): Permission[] {
+    return this.values();
+  }
+
+  /**
+   * Deliberately a summary rather than a listing. A set can hold hundreds of permissions and this
+   * type ends up attached to logs and spans; dumping the whole policy into telemetry on every
+   * request would be both noisy and a disclosure.
+   */
+  toString(): string {
+    return `PermissionSet(n=${String(this.size)})`;
+  }
+}
+
+/** A set that grants nothing. Shared singleton — every empty set behaves identically. */
+export const emptyPermissionSet = new PermissionSet();
+
+/** Builds a {@link PermissionSet} from a variadic list, for call sites that read better that way. */
+export function newPermissionSet(...perms: readonly Permission[]): PermissionSet {
+  return new PermissionSet(perms);
+}
+
+/**
+ * Rebuilds a {@link PermissionSet} from a decoded session payload — the browser half of the seam
+ * that {@link PermissionSet.toJSON} opens on the server.
+ *
+ * It is deliberately tolerant: anything that is not an array of strings hydrates to the empty set
+ * rather than throwing. A malformed payload should cost its holder authority, not the ability to
+ * render the page — and the alternative, throwing inside a React render, fails open in the sense
+ * that matters least and hardest.
+ */
+export function permissionSetFromJSON(value: unknown): PermissionSet {
+  if (!Array.isArray(value)) {
+    return emptyPermissionSet;
+  }
+  return new PermissionSet(value.filter((v): v is string => typeof v === "string"));
+}

--- a/packages/authorization/src/policy.test.ts
+++ b/packages/authorization/src/policy.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+
+import { isInvalidPolicy } from "./errors.js";
+import { emptyPermissionSet, PermissionSet } from "./permission.js";
+import {
+  expandInheritance,
+  isPolicyInvalidator,
+  validateRoles,
+  type PolicyInvalidator,
+  type PolicyResolver,
+  type Role,
+} from "./policy.js";
+
+const roles: Role[] = [
+  { name: "reader", permissions: ["recipes.read"] },
+  { name: "author", permissions: ["recipes.create"], inherits: ["reader"] },
+  { name: "editor", permissions: ["recipes.update"], inherits: ["author"] },
+];
+
+/** Asserts `fn` throws an InvalidPolicyError with the given `problem`. */
+function expectProblem(fn: () => unknown, problem: string): void {
+  try {
+    fn();
+  } catch (err) {
+    expect(isInvalidPolicy(err, problem as never)).toBe(true);
+    return;
+  }
+  expect.unreachable(`expected a ${problem} policy error`);
+}
+
+describe("validateRoles", () => {
+  it("accepts a well-formed policy", () => {
+    expect(() => {
+      validateRoles(roles);
+    }).not.toThrow();
+  });
+
+  it("accepts an empty policy", () => {
+    expect(() => {
+      validateRoles([]);
+    }).not.toThrow();
+  });
+
+  it("rejects an unnamed role", () => {
+    expectProblem(() => {
+      validateRoles([{ name: "", permissions: [] }]);
+    }, "empty-role-name");
+  });
+
+  it("rejects a duplicate role name", () => {
+    expectProblem(() => {
+      validateRoles([
+        { name: "reader", permissions: ["a"] },
+        { name: "reader", permissions: ["b"] },
+      ]);
+    }, "duplicate-role");
+  });
+
+  it("rejects inheritance from a role the policy does not define", () => {
+    expectProblem(() => {
+      validateRoles([{ name: "author", permissions: [], inherits: ["ghost"] }]);
+    }, "unknown-parent-role");
+  });
+
+  it("rejects a role inheriting from itself", () => {
+    expectProblem(() => {
+      validateRoles([{ name: "loop", permissions: [], inherits: ["loop"] }]);
+    }, "self-inheritance");
+  });
+
+  it("rejects an inheritance cycle", () => {
+    expectProblem(() => {
+      validateRoles([
+        { name: "a", permissions: [], inherits: ["b"] },
+        { name: "b", permissions: [], inherits: ["c"] },
+        { name: "c", permissions: [], inherits: ["a"] },
+      ]);
+    }, "inheritance-cycle");
+  });
+
+  it("names the same cycle on every run, so the error is actionable", () => {
+    const cyclic: Role[] = [
+      { name: "x", permissions: [], inherits: ["y"] },
+      { name: "y", permissions: [], inherits: ["x"] },
+      { name: "p", permissions: [], inherits: ["q"] },
+      { name: "q", permissions: [], inherits: ["p"] },
+    ];
+    const messages = new Set<string>();
+    for (let i = 0; i < 5; i += 1) {
+      try {
+        validateRoles(cyclic);
+      } catch (err) {
+        messages.add((err as Error).message);
+      }
+    }
+    expect(messages.size).toBe(1);
+  });
+
+  it("accepts a diamond, which is not a cycle", () => {
+    expect(() => {
+      validateRoles([
+        { name: "base", permissions: ["read"] },
+        { name: "left", permissions: ["l"], inherits: ["base"] },
+        { name: "right", permissions: ["r"], inherits: ["base"] },
+        { name: "top", permissions: [], inherits: ["left", "right"] },
+      ]);
+    }).not.toThrow();
+  });
+});
+
+describe("expandInheritance", () => {
+  it("applies inheritance transitively", () => {
+    const expanded = expandInheritance(roles);
+
+    expect(expanded.get("reader")?.values()).toEqual(["recipes.read"]);
+    expect(expanded.get("author")?.values()).toEqual(["recipes.create", "recipes.read"]);
+    // editor -> author -> reader, all three levels.
+    expect(expanded.get("editor")?.values()).toEqual([
+      "recipes.create",
+      "recipes.read",
+      "recipes.update",
+    ]);
+  });
+
+  it("unions several parents rather than ordering them", () => {
+    const expanded = expandInheritance([
+      { name: "base", permissions: ["read"] },
+      { name: "left", permissions: ["l"], inherits: ["base"] },
+      { name: "right", permissions: ["r"], inherits: ["base"] },
+      { name: "top", permissions: ["t"], inherits: ["left", "right"] },
+    ]);
+
+    expect(expanded.get("top")?.values()).toEqual(["l", "r", "read", "t"]);
+  });
+
+  it("validates first, so a malformed policy yields no partial expansion", () => {
+    expect(() =>
+      expandInheritance([{ name: "a", permissions: ["x"], inherits: ["ghost"] }]),
+    ).toThrow();
+  });
+
+  it("leaves the caller's roles untouched", () => {
+    const input: Role[] = [{ name: "reader", permissions: ["recipes.read"] }];
+    expandInheritance(input);
+    expect(input[0]?.permissions).toEqual(["recipes.read"]);
+  });
+});
+
+describe("isPolicyInvalidator", () => {
+  const base: PolicyResolver = {
+    permissionsForRoles: () => Promise.resolve(emptyPermissionSet),
+    roles: () => Promise.resolve([]),
+  };
+
+  it("is false for a resolver that only resolves", () => {
+    expect(isPolicyInvalidator(base)).toBe(false);
+  });
+
+  it("is true once both invalidation methods are present", () => {
+    const caching = {
+      ...base,
+      invalidate: () => Promise.resolve(),
+      invalidateAll: () => Promise.resolve(),
+    };
+    expect(isPolicyInvalidator(caching)).toBe(true);
+  });
+
+  it("is false when only half the contract is implemented", () => {
+    const halfway: PolicyResolver & Partial<PolicyInvalidator> = {
+      ...base,
+      invalidateAll: () => Promise.resolve(),
+    };
+    expect(isPolicyInvalidator(halfway)).toBe(false);
+  });
+});
+
+describe("PermissionSet as the resolver's currency", () => {
+  it("is what expansion produces, so backends are interchangeable by construction", () => {
+    for (const set of expandInheritance(roles).values()) {
+      expect(set).toBeInstanceOf(PermissionSet);
+    }
+  });
+});

--- a/packages/authorization/src/policy.ts
+++ b/packages/authorization/src/policy.ts
@@ -1,0 +1,190 @@
+import { InvalidPolicyError } from "./errors.js";
+import { PermissionSet, type Permission } from "./permission.js";
+
+/**
+ * A named grant of permissions, optionally inheriting from other roles.
+ *
+ * The same `Role[]` value seeds every backend, which is what makes them interchangeable — and it
+ * is the fix for the failure mode where a code-side role table and a stored seed drift apart
+ * because nothing ever checks them against each other.
+ */
+export interface Role {
+  /** Identifies the role. It is the string a principal's role assignments refer to, and it must be unique within a policy. */
+  name: string;
+  /** Human-facing documentation, surfaced by {@link PolicyResolver.roles} for admin tooling. No effect on resolution. */
+  description?: string;
+  /** The permissions this role grants directly, before inheritance is applied. */
+  permissions: readonly Permission[];
+  /**
+   * The roles this role inherits from. Inheritance is transitive: a role receives the permissions
+   * of its parents, its parents' parents, and so on. It is not an ordering — a role may inherit
+   * from several, and the result is their union.
+   */
+  inherits?: readonly string[];
+}
+
+/**
+ * Answers "what can these roles do".
+ *
+ * This is the only asynchronous, fallible, pluggable part of the package, and that is the whole
+ * design: resolving policy may hit a database; checking a permission never does. Callers resolve
+ * once when they build a session and check many times per request against the resulting
+ * {@link Grants}.
+ *
+ * Implementations must be safe for concurrent use.
+ */
+export interface PolicyResolver {
+  /**
+   * The effective permissions of the named roles with inheritance expanded — the union of what
+   * each role grants.
+   *
+   * Unknown role names contribute nothing rather than throwing: a policy that no longer defines a
+   * role a principal is still assigned must fail closed, not fail the request. Use {@link roles}
+   * to detect that case deliberately. Calling it with no roles returns an empty set.
+   */
+  permissionsForRoles(roles: readonly string[]): Promise<PermissionSet>;
+  /** Every role the policy defines, for introspection and admin tooling. The order is unspecified. */
+  roles(): Promise<Role[]>;
+}
+
+/**
+ * The optional half of a {@link PolicyResolver} that memoizes.
+ *
+ * It is declared apart from `PolicyResolver` so a caller handed a resolver it did not construct
+ * can reach invalidation without knowing which concrete type it was given — whether a cache sits
+ * in the chain is an assembly decision, not a call-site one:
+ *
+ * ```ts
+ * if (isPolicyInvalidator(resolver)) await resolver.invalidateAll();
+ * ```
+ *
+ * The process that edits policy is exactly the one that needs this, and the one least likely to
+ * know how its resolver was assembled.
+ */
+export interface PolicyInvalidator {
+  /** Drops the memoized resolution for an exact set of roles. */
+  invalidate(roles: readonly string[]): Promise<void>;
+  /** Makes every resolution this instance memoized unreachable. Process-local: other replicas wait out their TTL. */
+  invalidateAll(): Promise<void>;
+}
+
+/** Narrows a {@link PolicyResolver} to one that can also drop what it memoized. */
+export function isPolicyInvalidator(
+  resolver: PolicyResolver,
+): resolver is PolicyResolver & PolicyInvalidator {
+  const candidate = resolver as Partial<PolicyInvalidator>;
+  return (
+    typeof candidate.invalidate === "function" &&
+    typeof candidate.invalidateAll === "function"
+  );
+}
+
+/**
+ * Checks that `roles` form a well-formed policy: every role named, no duplicates, every parent
+ * defined, no role inheriting from itself, and no inheritance cycles.
+ *
+ * Every backend calls it, so a policy rejected in a compiled-in build is rejected on its way into
+ * storage too. Throws {@link InvalidPolicyError}; returns nothing on success.
+ */
+export function validateRoles(roles: readonly Role[]): void {
+  const byName = new Map<string, Role>();
+  for (const role of roles) {
+    if (role.name === "") {
+      throw new InvalidPolicyError("empty-role-name", "role name is empty");
+    }
+    if (byName.has(role.name)) {
+      throw new InvalidPolicyError("duplicate-role", `duplicate role name: ${role.name}`);
+    }
+    byName.set(role.name, role);
+  }
+
+  for (const role of roles) {
+    for (const parent of role.inherits ?? []) {
+      if (parent === role.name) {
+        throw new InvalidPolicyError(
+          "self-inheritance",
+          `role ${role.name} inherits from itself`,
+        );
+      }
+      if (!byName.has(parent)) {
+        throw new InvalidPolicyError(
+          "unknown-parent-role",
+          `role ${role.name} inherits unknown role ${parent}`,
+        );
+      }
+    }
+  }
+
+  detectCycles(byName);
+}
+
+/**
+ * Resolves every role to its effective permission set, with inheritance applied transitively.
+ *
+ * It validates first, so a malformed policy is rejected here rather than producing a
+ * partially-expanded result. This is the reference semantics for inheritance: any backend that
+ * expands some other way (in SQL, say) owes a test asserting it agrees with this function.
+ */
+export function expandInheritance(roles: readonly Role[]): Map<string, PermissionSet> {
+  validateRoles(roles);
+
+  const byName = new Map<string, Role>(roles.map((r) => [r.name, r]));
+  const expanded = new Map<string, PermissionSet>();
+
+  const resolve = (name: string): PermissionSet => {
+    const memo = expanded.get(name);
+    if (memo !== undefined) {
+      return memo;
+    }
+
+    const role = byName.get(name);
+    let set = new PermissionSet(role?.permissions ?? []);
+
+    // Marked before recursing so a cycle would terminate here. Cycles are already rejected by
+    // validateRoles; this keeps the function total rather than relying on that from a distance.
+    expanded.set(name, set);
+
+    for (const parent of role?.inherits ?? []) {
+      set = set.union(resolve(parent));
+      expanded.set(name, set);
+    }
+
+    return set;
+  };
+
+  for (const role of roles) {
+    resolve(role.name);
+  }
+
+  return expanded;
+}
+
+/** Walks the inheritance graph depth-first, reporting the first cycle it finds. */
+function detectCycles(byName: ReadonlyMap<string, Role>): void {
+  const state = new Map<string, "visiting" | "visited">();
+
+  const walk = (name: string, path: readonly string[]): void => {
+    const seen = state.get(name);
+    if (seen === "visiting") {
+      throw new InvalidPolicyError(
+        "inheritance-cycle",
+        `role inheritance cycle: ${[...path, name].join(" -> ")}`,
+      );
+    }
+    if (seen === "visited") {
+      return;
+    }
+
+    state.set(name, "visiting");
+    for (const parent of byName.get(name)?.inherits ?? []) {
+      walk(parent, [...path, name]);
+    }
+    state.set(name, "visited");
+  };
+
+  // Sorted so a policy with more than one cycle reports the same one every run; an error that
+  // moves between runs is miserable to act on.
+  for (const name of [...byName.keys()].sort()) {
+    walk(name, []);
+  }
+}

--- a/packages/authorization/src/providers/static.test.ts
+++ b/packages/authorization/src/providers/static.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { isInvalidPolicy } from "../errors.js";
+import type { Role } from "../policy.js";
+
+import { StaticPolicyResolver } from "./static.js";
+
+const roles: Role[] = [
+  { name: "reader", description: "reads recipes", permissions: ["recipes.read"] },
+  { name: "author", permissions: ["recipes.create"], inherits: ["reader"] },
+  { name: "billing", permissions: ["billing.refund"] },
+];
+
+describe("StaticPolicyResolver", () => {
+  it("resolves a single role to its effective permissions", async () => {
+    const resolver = new StaticPolicyResolver(roles);
+    const set = await resolver.permissionsForRoles(["author"]);
+    expect(set.values()).toEqual(["recipes.create", "recipes.read"]);
+  });
+
+  it("unions several roles", async () => {
+    const resolver = new StaticPolicyResolver(roles);
+    const set = await resolver.permissionsForRoles(["author", "billing"]);
+    expect(set.values()).toEqual(["billing.refund", "recipes.create", "recipes.read"]);
+  });
+
+  it("resolves the same answer regardless of the order roles are given", () => {
+    const resolver = new StaticPolicyResolver(roles);
+    expect(
+      resolver
+        .resolve(["billing", "author"])
+        .equals(resolver.resolve(["author", "billing"])),
+    ).toBe(true);
+  });
+
+  it("returns the memoized set on a repeat multi-role resolution", () => {
+    const resolver = new StaticPolicyResolver(roles);
+    expect(resolver.resolve(["author", "billing"])).toBe(
+      resolver.resolve(["author", "billing"]),
+    );
+  });
+
+  it("grants nothing for no roles", async () => {
+    const resolver = new StaticPolicyResolver(roles);
+    expect((await resolver.permissionsForRoles([])).isEmpty()).toBe(true);
+  });
+
+  it("lets an unknown role contribute nothing rather than throwing", async () => {
+    // A principal still assigned a role the policy has since dropped loses that authority,
+    // rather than losing the ability to make requests at all.
+    const resolver = new StaticPolicyResolver(roles);
+    expect((await resolver.permissionsForRoles(["ghost"])).isEmpty()).toBe(true);
+    expect((await resolver.permissionsForRoles(["ghost", "billing"])).values()).toEqual([
+      "billing.refund",
+    ]);
+  });
+
+  it("rejects a malformed policy at construction", () => {
+    // A policy mistake fails at startup rather than as a puzzling denial later.
+    try {
+      new StaticPolicyResolver([{ name: "loop", permissions: [], inherits: ["loop"] }]);
+    } catch (err) {
+      expect(isInvalidPolicy(err, "self-inheritance")).toBe(true);
+      return;
+    }
+    expect.unreachable("expected construction to throw");
+  });
+
+  it("builds with no roles, denies everything, and warns", async () => {
+    // The default configuration has to build — but a service that denies every request is far
+    // more likely a missing configuration than an intent, so it says so.
+    const warn = vi.fn();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+      child: (): unknown => logger,
+    };
+
+    const resolver = new StaticPolicyResolver([], {
+      logger: logger as never,
+    });
+
+    expect((await resolver.permissionsForRoles(["anything"])).isEmpty()).toBe(true);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("does not warn when a policy was supplied", () => {
+    const warn = vi.fn();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn,
+      error: vi.fn(),
+      child: (): unknown => logger,
+    };
+
+    new StaticPolicyResolver(roles, { logger: logger as never });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("resolves synchronously for callers that know the policy is compiled in", () => {
+    // Public on purpose: a static policy genuinely resolves without I/O, and a caller should not
+    // have to await a promise that was never going to yield.
+    const resolver = new StaticPolicyResolver(roles);
+    expect(resolver.resolve(["reader"]).has("recipes.read")).toBe(true);
+  });
+
+  it("agrees with itself across the sync and async paths", async () => {
+    const resolver = new StaticPolicyResolver(roles);
+    const [sync, async] = [
+      resolver.resolve(["author", "billing"]),
+      await resolver.permissionsForRoles(["author", "billing"]),
+    ];
+    expect(sync.equals(async)).toBe(true);
+  });
+});
+
+describe("StaticPolicyResolver policy isolation", () => {
+  it("copies the policy in, so a later mutation cannot edit it", async () => {
+    const permissions = ["recipes.read"];
+    const mutable: Role[] = [{ name: "reader", permissions }];
+    const resolver = new StaticPolicyResolver(mutable);
+
+    permissions.push("recipes.delete");
+    mutable.push({ name: "sneaky", permissions: ["everything"] });
+
+    expect((await resolver.permissionsForRoles(["reader"])).values()).toEqual([
+      "recipes.read",
+    ]);
+    expect((await resolver.permissionsForRoles(["sneaky"])).isEmpty()).toBe(true);
+  });
+
+  it("hands out roles that share nothing with its own state", async () => {
+    const resolver = new StaticPolicyResolver(roles);
+
+    const first = await resolver.roles();
+    // Cast because `Role.permissions` is readonly: the point of the test is that reaching past
+    // the type still cannot touch the resolver's copy.
+    (first[0]?.permissions as string[]).push("injected");
+    first.length = 0;
+
+    const second = await resolver.roles();
+    expect(second).toHaveLength(roles.length);
+    expect(second.find((r) => r.name === "reader")?.permissions).toEqual([
+      "recipes.read",
+    ]);
+    // Two calls share no array either, so one caller's edit cannot reach another's copy.
+    expect(second[0]).not.toBe(first[0]);
+  });
+
+  it("reports every role, with descriptions and inheritance intact", async () => {
+    const listed = await new StaticPolicyResolver(roles).roles();
+    expect(listed.map((r) => r.name).sort()).toEqual(["author", "billing", "reader"]);
+    expect(listed.find((r) => r.name === "reader")?.description).toBe("reads recipes");
+    expect(listed.find((r) => r.name === "author")?.inherits).toEqual(["reader"]);
+  });
+});

--- a/packages/authorization/src/providers/static.ts
+++ b/packages/authorization/src/providers/static.ts
@@ -1,0 +1,115 @@
+import { ensureLogger, type ObservabilityDeps } from "@primandproper/observability";
+
+import { emptyPermissionSet, PermissionSet } from "../permission.js";
+import { expandInheritance, type PolicyResolver, type Role } from "../policy.js";
+
+/**
+ * A {@link PolicyResolver} whose policy is fixed at construction.
+ *
+ * This is the default backend and the one to reach for until something forces otherwise: it needs
+ * no database, no migrations, and no configuration, and it resolves without I/O. Policy lives
+ * wherever the caller declares its roles — as TypeScript constants, or as JSON/YAML loaded into
+ * config.
+ *
+ * Graduate to a stored policy only when roles themselves must become editable data: when an
+ * operator has to define a new role, or change what an existing one grants, without shipping a
+ * release. Reassigning which roles a principal holds does not require it — role assignments belong
+ * to the consumer either way, because they reference the consumer's own users and tenants. This
+ * package owns policy, not assignment.
+ */
+export class StaticPolicyResolver implements PolicyResolver {
+  readonly #expanded: ReadonlyMap<string, PermissionSet>;
+  readonly #roles: readonly Role[];
+  readonly #memo = new Map<string, PermissionSet>();
+
+  /**
+   * Builds a resolver over `roles`, expanding inheritance once.
+   *
+   * It throws {@link InvalidPolicyError} for a malformed policy — an unnamed role, a duplicate, a
+   * parent that is not defined, or an inheritance cycle — so a policy mistake fails at startup
+   * rather than as a puzzling denial later.
+   *
+   * Zero roles is valid and produces a resolver that denies everything. That is deliberate: the
+   * default configuration has to build, or the default provider would not be usable without setup.
+   * It logs a warning, because a service that denies every request is far more likely to be a
+   * missing configuration than an intent.
+   */
+  constructor(roles: readonly Role[] = [], deps?: ObservabilityDeps) {
+    this.#expanded = expandInheritance(roles);
+    // Cloned so a caller mutating its own array afterwards cannot edit the live policy.
+    this.#roles = roles.map((role) => ({
+      ...role,
+      permissions: [...role.permissions],
+      ...(role.inherits === undefined ? {} : { inherits: [...role.inherits] }),
+    }));
+
+    if (roles.length === 0) {
+      ensureLogger(deps?.logger)
+        .child("authorization_static")
+        .warn(
+          "static policy resolver constructed with no roles; all authorization checks will deny",
+        );
+    }
+  }
+
+  /**
+   * The union of the effective permissions of the named roles. It never rejects: the policy was
+   * validated at construction and resolution touches nothing outside this process.
+   */
+  async permissionsForRoles(roles: readonly string[]): Promise<PermissionSet> {
+    return this.resolve(roles);
+  }
+
+  /**
+   * The synchronous core. It is public because a static policy genuinely resolves without I/O, and
+   * a caller that knows it configured this backend should not have to `await` a promise that was
+   * never going to yield. Code written against {@link PolicyResolver} uses the async method and
+   * stays portable across backends.
+   */
+  resolve(roles: readonly string[]): PermissionSet {
+    const [only] = roles;
+    if (only === undefined) {
+      return emptyPermissionSet;
+    }
+    if (roles.length === 1) {
+      // The overwhelmingly common case, and it needs neither a union nor a memo entry: the
+      // expansion map already holds exactly this answer.
+      return this.#expanded.get(only) ?? emptyPermissionSet;
+    }
+
+    const key = memoKey(roles);
+    const memo = this.#memo.get(key);
+    if (memo !== undefined) {
+      return memo;
+    }
+
+    // Unknown roles contribute nothing rather than throwing, so a principal still assigned a role
+    // the policy has since dropped loses that authority instead of losing the ability to make
+    // requests at all.
+    const sets = roles
+      .map((name) => this.#expanded.get(name))
+      .filter((s): s is PermissionSet => s !== undefined);
+
+    const union = emptyPermissionSet.union(...sets);
+    this.#memo.set(key, union);
+
+    return union;
+  }
+
+  /** Every role in the policy. The result shares nothing with the resolver's state. */
+  async roles(): Promise<Role[]> {
+    return this.#roles.map((role) => ({
+      ...role,
+      permissions: [...role.permissions],
+      ...(role.inherits === undefined ? {} : { inherits: [...role.inherits] }),
+    }));
+  }
+}
+
+/**
+ * Builds a stable key for a set of role names. It sorts a copy so the same roles in a different
+ * order hit the same entry, and joins on NUL because a role name cannot usefully contain one.
+ */
+function memoKey(roles: readonly string[]): string {
+  return [...roles].sort().join("\u0000");
+}

--- a/packages/authorization/tsconfig.json
+++ b/packages/authorization/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/authorization/tsup.config.ts
+++ b/packages/authorization/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  {
+    entry: { "index.node": "src/index.node.ts" },
+    platform: "node",
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+    clean: true,
+  },
+  {
+    entry: { "index.browser": "src/index.browser.ts" },
+    platform: "browser",
+    format: ["esm"],
+    dts: true,
+    sourcemap: true,
+    treeshake: true,
+    clean: false,
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,18 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
 
+  packages/authorization:
+    dependencies:
+      '@primandproper/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@primandproper/observability':
+        specifier: workspace:*
+        version: link:../observability
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
+
   packages/bitmask: {}
 
   packages/cache:


### PR DESCRIPTION
Refs #9 — the checking half plus static policy resolution. Not a complete port; see "What is still open".

**Provenance:** `permission.ts`, `grants.ts`, `policy.ts`, `errors.ts`, and `providers/static.ts` were already sitting untracked in the working tree — this PR does not rewrite them. It adds what they needed to become a package: entry points, tests, a README, and the portability lint rule. Three doc comments referenced an `Enforcer` / `RequirementsBuilder` / config factory that do not exist yet; those now point at the README's "Not ported" section instead of at phantom APIs.

It also fixes the immediate annoyance: with no entry point `tsup` failed with `Cannot find index.node`, and with no test files `vitest` exited 1, so a bare `pnpm test` at the repo root was red. Both are green now.

## The seam this defends

```
resolve   role names -> permission set   once per session   may do I/O
check     permission in set              many per request   never does
```

Only resolution is pluggable. **Checking is synchronous, infallible, and allocation-free**, which is what stops a check inside a loop from becoming N round trips — and in TypeScript it also means checks work in a React render, so the permission set gating a handler and the one deciding which controls to draw are the same code rather than two implementations that drift.

## What is covered

- Universal `PermissionSet` / `Grants` with synchronous `has` / `hasAll` / `hasAny` / `evaluate`.
- `evaluate` returns an entry per requested permission **including the `false` ones**, so "denied" and "not asked" stay distinguishable across the wire.
- The `GrantsExtractor` seam, with sets that grant nothing dropped — an administrator acting on a tenant they do not belong to needs no branch anywhere — and a zero value that denies.
- `StaticPolicyResolver`, transitive inheritance expansion, and policy validation that rejects rather than partially applies.
- Isomorphic exports: checks in both entries, resolution node-only.
- The empty-list hazard documented as a matrix in one place, with the caveat that the enforcement layer which would guard it is not ported yet.
- `allowAll()` is a function call at a call site, not a config flag — turning authorization off should be visible in a diff.

## Tests

70 tests. Beyond the happy paths, they pin the decisions that are easy to regress: `hasAll([])` is vacuously `true` (asserted deliberately, as the hazard it is), a malformed session payload hydrates to *no* authority rather than throwing mid-render, `PermissionDeniedError` never names the permission it denied, an unknown role contributes nothing instead of throwing, a policy with two cycles reports the same one every run, and the resolver's defensive copies hold when a caller mutates the array it passed in or the roles it got back.

## What is still open on #9

- **Server enforcement** — the middleware that denies an empty requirement list, and the frozen requirements table that refuses to build one. The issue notes a real opportunity here that Go lacked: with hono/express/fastify the route table is enumerable at startup, so "every route declares permissions or is explicitly public" is checkable at boot.
- **A database-backed resolver**, and the cached wrapper that `PolicyInvalidator` exists for.
- **A `config.ts` provider factory** — resolvers are constructed directly for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhrZu2juqReVTho9PWQ5e