### PR TITLE
feat(authorization): server enforcement and boot-time route coverage

### DIFF
--- a/.changeset/authorization-enforcement.md
+++ b/.changeset/authorization-enforcement.md
@@ -1,0 +1,38 @@
+---
+"@primandproper/authorization": minor
+---
+
+Add the server enforcement layer: `Enforcer`, a frozen `Requirements` table, and a boot-time route
+coverage check.
+
+The checking half already shipped. What was missing was the two rows of the empty-list matrix that
+actually do the guarding — until now they described code that did not exist, so a caller building a
+requirement list from anything other than a literal had to check it for emptiness itself, which is
+precisely the burden an enforcement layer exists to remove.
+
+`Enforcer` decides and says so by throwing. The decision is still `Grants.hasAll`; what the
+enforcer adds is the part that is easy to get wrong exactly once. **An empty requirement list
+denies** — set algebra says vacuously true, but a guard installed with an empty list is far more
+likely a list that came back empty from configuration than an intent to admit everyone, and a route
+needing no authorization simply carries no guard. `RequirementsBuilder.build()` refuses outright,
+reporting every problem it found rather than the first, because a table assembled from a dozen
+feature modules usually has more than one.
+
+Requirements are declared either at the route's registration site (`enforcer.require(...)`) or in a
+frozen table consulted by one middleware (`enforcer.enforce(keyOf)`), where **an undeclared key is
+denied** — being public is a declaration, never an omission. Middleware is `(ctx, next)`, generic
+over the context type; a denial throws `PermissionDeniedError` rather than writing a response,
+since this package cannot know a consumer's error envelope and routing the denial through the
+framework's own error hook makes it identical to a handler that threw it.
+
+`assertRoutesDeclared` is the piece platform-go could not have. Its HTTP middleware runs before the
+mux has matched, so an unguarded route is undetectable there; in TypeScript the route table is
+enumerable at startup, so "every registered route either requires permissions or is explicitly
+marked public" becomes a fact checked before the first request. It reports a rename from both sides
+— the new name undeclared, the old one stale — which names the mistake more precisely than either
+half alone.
+
+`auditOnly` records every decision without acting on it, for turning enforcement on across a
+service that never had it. Five instruments back it, and three of them (`missing_grants`,
+`undeclared`, `empty_requirements`) count wiring bugs rather than misbehaving callers — those are
+the ones to alert on.

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ logic, one build), **isomorphic** (same import resolves per-environment), **serv
 
 ### Isomorphic
 
-| Package                        | Purpose                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------- |
-| `@primandproper/observability` | `Logger` (pino on Node, console in browser) + OTel tracer/meter aliases   |
-| `@primandproper/cache`         | `Cache<T>` (memory/redis on Node, memory/web-storage in browser)          |
-| `@primandproper/cryptography`  | `Encryptor` + `Hasher` over WebCrypto                                     |
-| `@primandproper/random`        | Cryptographically secure random (hex, base32, base64url) over WebCrypto   |
-| `@primandproper/compression`   | `Compressor` interface with swappable providers                           |
-| `@primandproper/cookies`       | `CookieStore` interface with swappable providers                          |
-| `@primandproper/httpclient`    | Thin `fetch` wrapper with OpenTelemetry spans                             |
-| `@primandproper/ratelimiting`  | `RateLimiter` interface with swappable providers                          |
-| `@primandproper/eventstream`   | `EventStream` over SSE and WebSocket                                      |
-| `@primandproper/analytics`     | `EventReporter` interface with swappable providers                        |
-| `@primandproper/eventcapture`  | Non-blocking high-volume event capture draining to a swappable sink       |
-| `@primandproper/idempotency`   | At-most-once execution per client key (manager on Node, keys in either)   |
-| `@primandproper/authorization` | Synchronous permission checks everywhere, policy resolution on the server |
+| Package                        | Purpose                                                                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| `@primandproper/observability` | `Logger` (pino on Node, console in browser) + OTel tracer/meter aliases                   |
+| `@primandproper/cache`         | `Cache<T>` (memory/redis on Node, memory/web-storage in browser)                          |
+| `@primandproper/cryptography`  | `Encryptor` + `Hasher` over WebCrypto                                                     |
+| `@primandproper/random`        | Cryptographically secure random (hex, base32, base64url) over WebCrypto                   |
+| `@primandproper/compression`   | `Compressor` interface with swappable providers                                           |
+| `@primandproper/cookies`       | `CookieStore` interface with swappable providers                                          |
+| `@primandproper/httpclient`    | Thin `fetch` wrapper with OpenTelemetry spans                                             |
+| `@primandproper/ratelimiting`  | `RateLimiter` interface with swappable providers                                          |
+| `@primandproper/eventstream`   | `EventStream` over SSE and WebSocket                                                      |
+| `@primandproper/analytics`     | `EventReporter` interface with swappable providers                                        |
+| `@primandproper/eventcapture`  | Non-blocking high-volume event capture draining to a swappable sink                       |
+| `@primandproper/idempotency`   | At-most-once execution per client key (manager on Node, keys in either)                   |
+| `@primandproper/authorization` | Synchronous permission checks everywhere, policy resolution and enforcement on the server |
 
 ### Server-only
 

--- a/packages/authorization/README.md
+++ b/packages/authorization/README.md
@@ -74,16 +74,89 @@ quantifier, and it is a live hazard: a requirement list that accidentally resolv
 permissions would authorize everyone. The set algebra stays honest and each declaration site
 guards, which means the sites answer the empty case differently **on purpose**:
 
-| site                                         | empty list                                    |
-| -------------------------------------------- | --------------------------------------------- |
-| `PermissionSet.hasAll()` / `Grants.hasAll()` | `true` — set algebra                          |
-| server enforcement middleware                | denies — far more likely a bug than an intent |
-| a frozen requirements table                  | refuses to build at all                       |
+| site                                            | empty list                                    |
+| ----------------------------------------------- | --------------------------------------------- |
+| `PermissionSet.hasAll()` / `Grants.hasAll()`    | `true` — set algebra                          |
+| `Enforcer.decide()` / `require()` / `enforce()` | denies — far more likely a bug than an intent |
+| `RequirementsBuilder.build()`                   | refuses to build at all                       |
 
 "Empty means allow" is therefore only ever safe with a list you wrote **literally**. Anything
-derived from configuration, a database, or a lookup must be checked for emptiness first. The last
-two rows describe the enforcement layer, which is not ported yet — see "Not ported" below — so
-today that check is the caller's job.
+derived from configuration, a database, or a lookup should reach an `Enforcer` rather than
+`hasAll` directly, because the enforcement layer is where that check already lives.
+
+## Server enforcement (server only)
+
+An `Enforcer` decides whether a request may proceed and says so by throwing. The decision is still
+just `Grants.hasAll` — what the enforcer adds is the part that is easy to get wrong exactly once:
+the empty-list guard above, fail-closed behaviour for a route nobody declared, and instruments
+that tell "a caller overreached" apart from "this service is not enforcing what its author thought
+it was".
+
+Two ways to declare what a route needs, and they are the two platform-go ships:
+
+```ts
+const enforcer = newEnforcer({
+  extract: (c) => c.get("grants"),
+  deps: { logger, metrics },
+});
+
+// At the registration site — the requirement sits next to the handler it guards.
+app.get("/recipes/:id", enforcer.require("recipes.read"), readRecipe);
+```
+
+```ts
+// Or from a frozen table, installed once. An undeclared route is denied.
+const requirements = newRequirements()
+  .require("GET /recipes/:id", "recipes.read")
+  .markPublic("GET /healthz")
+  .build();
+
+const enforcer = newEnforcer({ extract, requirements });
+app.use(enforcer.enforce((c) => `${c.req.method} ${c.req.routePath}`));
+```
+
+Middleware is `(ctx, next)` — hono- and koa-shaped, generic over the context type, with an express
+adapter shown in the `Middleware` doc comment. A denial **throws** `PermissionDeniedError` rather
+than writing a response: this package cannot know a consumer's error envelope and should not guess
+at one, and routing the denial through the framework's own error hook is what makes it look
+identical to a handler that threw the same error itself.
+
+### The table is the stronger of the two
+
+Declaring at the registration site puts the requirement next to the handler, which is where a
+reader is most likely to notice its absence — but nothing can detect a route registered with no
+guard at all. platform-go says so plainly and stops there, because its HTTP middleware runs before
+the mux has matched and a route pattern is not knowable at that point.
+
+TypeScript is not stuck with that. The route table is enumerable at startup, so the check Go lists
+as its known gap is one call:
+
+```ts
+assertRoutesDeclared(
+  app.routes.map((r) => `${r.method} ${r.path}`),
+  requirements,
+); // throws RouteCoverageError naming every uncovered route
+```
+
+Run it at boot and in a test. It reports a rename from both sides — the new name as undeclared, the
+old one as stale — which names the mistake far more precisely than either half alone.
+
+### Rolling it out
+
+`auditOnly: true` evaluates and records every decision but denies nothing. Turning enforcement on
+across a service that never had it is otherwise a bet that every declaration is right on the first
+try: deploy with it, watch `authorization.denials` and `authorization.undeclared` settle to zero,
+then remove it. It is the only mode in which an unauthorized request proceeds, which is why it is a
+code-level option rather than configuration, and why it announces itself in the log at
+construction.
+
+### Watching it
+
+`authorization.checks`, `authorization.denials`, `authorization.missing_grants`,
+`authorization.undeclared`, and `authorization.empty_requirements`, each carrying the declared
+route key when enforcement was table-driven. Alert on the last three: they mean the wiring is
+wrong, not that a caller misbehaved. The key is a declared route pattern, so its cardinality is
+bounded by the table — a raw URL path is not, and is never used as a label.
 
 ## Policy resolution (server only)
 
@@ -123,7 +196,7 @@ say) owes a test asserting it agrees with this function.
 ## The isomorphic split
 
 - `index.browser.ts` — permission sets, grants, and errors: the checking half.
-- `index.node.ts` — the same, plus policy resolution.
+- `index.node.ts` — the same, plus policy resolution and enforcement.
 
 Resolution is absent from the browser rather than stubbed. It may do I/O and belongs to the
 server, which hands the browser the resolved set; a browser that could resolve policy would be a
@@ -146,12 +219,7 @@ adding context at a boundary does not turn a denial into a 500.
 
 ## Not ported
 
-- **Server enforcement** — the middleware that denies an empty requirement list, and the frozen
-  requirements table that refuses to build one. TypeScript has a real opportunity here that Go
-  lacked: with hono/express/fastify the route table is enumerable at startup, so a boot-time check
-  that every registered route either declares permissions or is explicitly marked public is
-  achievable.
 - **A database-backed resolver**, and the cached-resolver wrapper `PolicyInvalidator` exists for.
-- **A `config.ts` provider factory** — resolvers are constructed directly for now.
+- **A `config.ts` provider factory** — resolvers and enforcers are constructed directly for now.
 
 Tracked in [#9](https://github.com/primandproper/platform-ts/issues/9).

--- a/packages/authorization/src/enforcement.test.ts
+++ b/packages/authorization/src/enforcement.test.ts
@@ -1,0 +1,377 @@
+import type { MeterProvider, ObservabilityDeps } from "@primandproper/observability";
+import { describe, expect, it, vi } from "vitest";
+
+import { newEnforcer, type Decision } from "./enforcement.js";
+import { isPermissionDenied, PermissionDeniedError } from "./errors.js";
+import {
+  allowAll,
+  denyAll,
+  newGrants,
+  type Grants,
+  type GrantsExtractor,
+} from "./grants.js";
+import { PermissionSet } from "./permission.js";
+import { newRequirements } from "./requirements.js";
+
+/** The request context these tests enforce over: whatever authority the caller carries. */
+interface Ctx {
+  grants?: Grants;
+  route?: string;
+}
+
+const extract: GrantsExtractor<Ctx> = (ctx) => ctx.grants;
+
+function holding(...perms: readonly string[]): Ctx {
+  return { grants: newGrants(new PermissionSet(perms)) };
+}
+
+/** A meter provider that tallies counter `add`s by `${instrument}:${key}`. */
+function recordingMeter(): { provider: MeterProvider; counts: Record<string, number> } {
+  const counts: Record<string, number> = {};
+  const counter = (name: string) => ({
+    add: (value: number, attributes?: { key?: string }) => {
+      const tally = `${name}:${attributes?.key ?? ""}`;
+      counts[tally] = (counts[tally] ?? 0) + value;
+    },
+  });
+  const meter = {
+    createCounter: (name: string) => counter(name),
+    createUpDownCounter: (name: string) => counter(name),
+    createHistogram: () => ({ record: () => undefined }),
+    createGauge: () => ({ record: () => undefined }),
+  };
+  return { provider: { getMeter: () => meter } as unknown as MeterProvider, counts };
+}
+
+/** A logger that records what was said at each level. */
+function recordingLogger(): {
+  deps: ObservabilityDeps;
+  errors: string[];
+  infos: string[];
+} {
+  const errors: string[] = [];
+  const infos: string[] = [];
+  const logger = {
+    debug: vi.fn(),
+    info: (message: string) => infos.push(message),
+    warn: vi.fn(),
+    error: (message: string) => errors.push(message),
+    with: (): unknown => logger,
+    child: (): unknown => logger,
+    withSpan: (): unknown => logger,
+  };
+  return { deps: { logger: logger as never }, errors, infos };
+}
+
+/** Runs a middleware and reports whether it reached the handler. */
+async function run(
+  middleware: (ctx: Ctx, next: () => unknown) => Promise<void>,
+  ctx: Ctx,
+): Promise<{ reached: boolean; err: unknown }> {
+  let reached = false;
+  try {
+    await middleware(ctx, () => {
+      reached = true;
+    });
+  } catch (err) {
+    return { reached, err };
+  }
+  return { reached, err: undefined };
+}
+
+describe("Enforcer.decide", () => {
+  it("admits a request holding every required permission", () => {
+    const enforcer = newEnforcer({ extract });
+    const decision = enforcer.decide(holding("things.read", "things.write"), [
+      "things.read",
+      "things.write",
+    ]);
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe("allowed");
+  });
+
+  it("denies a request holding only a subset, and says what was missing", () => {
+    const enforcer = newEnforcer({ extract });
+    const decision = enforcer.decide(holding("things.read"), [
+      "things.read",
+      "things.write",
+    ]);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("missing-permissions");
+    expect(decision.missing).toEqual(["things.write"]);
+  });
+
+  it("denies when no authority could be determined", () => {
+    const enforcer = newEnforcer({ extract });
+    const decision = enforcer.decide({}, ["things.read"]);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("no-grants");
+  });
+
+  it("denies grants that permit nothing", () => {
+    const enforcer = newEnforcer({ extract });
+    expect(enforcer.decide({ grants: denyAll() }, ["things.read"]).allowed).toBe(false);
+  });
+
+  it("denies an empty requirement list rather than vacuously allowing it", () => {
+    // The middleware row of the empty-list matrix. `Grants.hasAll([])` is honestly `true` — set
+    // algebra — but a guard installed with an empty list is far more likely a list that came back
+    // empty from configuration than an intent to admit everyone.
+    const enforcer = newEnforcer({ extract });
+    const decision = enforcer.decide(holding("things.read"), []);
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe("empty-requirement");
+  });
+
+  it("admits everything for allowAll grants — but still denies an empty requirement", () => {
+    // The escape hatch turns the policy off, not the guard against a requirement list that
+    // reached zero length by accident.
+    const enforcer = newEnforcer({ extract });
+
+    expect(enforcer.decide({ grants: allowAll() }, ["anything.at.all"]).allowed).toBe(
+      true,
+    );
+    expect(enforcer.decide({ grants: allowAll() }, []).reason).toBe("empty-requirement");
+  });
+});
+
+describe("Enforcer.require", () => {
+  it("reaches the handler for an authorized request", async () => {
+    const enforcer = newEnforcer({ extract });
+    const { reached, err } = await run(
+      enforcer.require("things.read"),
+      holding("things.read"),
+    );
+
+    expect(reached).toBe(true);
+    expect(err).toBeUndefined();
+  });
+
+  it("throws a permission denial instead of reaching the handler", async () => {
+    // Denial travels as an error with a stable code so the framework's own error hook turns it
+    // into a 403 — identical to a handler that threw the same error itself.
+    const enforcer = newEnforcer({ extract });
+    const { reached, err } = await run(
+      enforcer.require("things.write"),
+      holding("things.read"),
+    );
+
+    expect(reached).toBe(false);
+    expect(isPermissionDenied(err)).toBe(true);
+  });
+
+  it("does not disclose the permission taxonomy in the message", () => {
+    // The security assertion: which permission was missing goes to the log and the span, and stops
+    // there. Naming it in a response tells an unauthorized caller what to go looking for.
+    const err = new PermissionDeniedError(["billing.refund"]);
+
+    expect(err.message).toBe("permission denied");
+    expect(err.message).not.toContain("billing.refund");
+    expect(err.missing).toEqual(["billing.refund"]);
+  });
+
+  it("denies a route guarded with no permissions", async () => {
+    const enforcer = newEnforcer({ extract });
+    const { reached, err } = await run(enforcer.require(), holding("things.read"));
+
+    expect(reached).toBe(false);
+    expect(isPermissionDenied(err)).toBe(true);
+  });
+
+  it("copies the permission list, so a later mutation cannot alter the requirement", async () => {
+    const enforcer = newEnforcer({ extract });
+    const perms = ["things.read"];
+    const middleware = enforcer.require(...perms);
+    perms[0] = "things.write";
+
+    const { reached } = await run(middleware, holding("things.read"));
+
+    expect(reached).toBe(true);
+  });
+});
+
+describe("Enforcer.enforce", () => {
+  const requirements = newRequirements()
+    .require("GET /things/:id", "things.read")
+    .markPublic("GET /healthz")
+    .build();
+
+  const keyOf = (ctx: Ctx): string | undefined => ctx.route;
+
+  it("admits a request satisfying its declared requirement", async () => {
+    const enforcer = newEnforcer({ extract, requirements });
+    const { reached } = await run(enforcer.enforce(keyOf), {
+      ...holding("things.read"),
+      route: "GET /things/:id",
+    });
+
+    expect(reached).toBe(true);
+  });
+
+  it("admits a public route without consulting grants at all", async () => {
+    const enforcer = newEnforcer({ extract, requirements });
+    const { reached } = await run(enforcer.enforce(keyOf), { route: "GET /healthz" });
+
+    expect(reached).toBe(true);
+  });
+
+  it("denies an undeclared route", async () => {
+    // Fail closed: being public is a declaration, never an omission, so forgetting to declare a
+    // route produces a denial rather than an opening.
+    const enforcer = newEnforcer({ extract, requirements });
+    const { reached, err } = await run(enforcer.enforce(keyOf), {
+      ...holding("things.read", "things.admin"),
+      route: "DELETE /things/:id",
+    });
+
+    expect(reached).toBe(false);
+    expect(isPermissionDenied(err)).toBe(true);
+  });
+
+  it("denies a context whose key could not be derived", async () => {
+    const enforcer = newEnforcer({ extract, requirements });
+    const { reached, err } = await run(enforcer.enforce(keyOf), holding("things.read"));
+
+    expect(reached).toBe(false);
+    expect(isPermissionDenied(err)).toBe(true);
+  });
+
+  it("reports the key on the decision", () => {
+    const enforcer = newEnforcer({ extract, requirements });
+    const decision = enforcer.decideDeclared(holding("things.read"), "GET /things/:id");
+
+    expect(decision.key).toBe("GET /things/:id");
+  });
+
+  it("refuses to decide from a table it was not given", () => {
+    const enforcer = newEnforcer({ extract });
+    expect(() =>
+      enforcer.decideDeclared(holding("things.read"), "GET /things/:id"),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("Enforcer.authorize", () => {
+  it("returns for an authorized request and throws otherwise", () => {
+    const enforcer = newEnforcer({ extract });
+
+    expect(() => {
+      enforcer.authorize(holding("things.read"), "things.read");
+    }).not.toThrow();
+    expect(() => {
+      enforcer.authorize(holding("things.read"), "things.write");
+    }).toThrow();
+  });
+
+  it("denies when called with no permissions", () => {
+    const enforcer = newEnforcer({ extract });
+    expect(() => {
+      enforcer.authorize(holding("things.read"));
+    }).toThrow();
+  });
+});
+
+describe("Enforcer audit-only mode", () => {
+  const requirements = newRequirements().require("GET /things", "things.read").build();
+
+  it("records the denial but lets the request through", async () => {
+    const { provider, counts } = recordingMeter();
+    const enforcer = newEnforcer({
+      extract,
+      requirements,
+      auditOnly: true,
+      deps: { metrics: provider },
+    });
+
+    const decision = enforcer.decideDeclared(holding("other.thing"), "GET /things");
+    const { reached, err } = await run(
+      enforcer.enforce((ctx) => ctx.route),
+      {
+        ...holding("other.thing"),
+        route: "GET /things",
+      },
+    );
+
+    // The decision stays honest; only what the enforcer does about it changes.
+    expect(decision.allowed).toBe(false);
+    expect(reached).toBe(true);
+    expect(err).toBeUndefined();
+    expect(counts["authorization.denials:GET /things"]).toBe(2);
+  });
+
+  it("announces itself at construction, since it is the only mode that admits the unauthorized", () => {
+    const { deps, infos } = recordingLogger();
+    newEnforcer({ extract, auditOnly: true, deps });
+
+    expect(infos.join("\n")).toContain("audit-only");
+  });
+
+  it("is off unless asked for", () => {
+    expect(newEnforcer({ extract }).isAuditOnly()).toBe(false);
+  });
+});
+
+describe("Enforcer instruments", () => {
+  const requirements = newRequirements()
+    .require("GET /things", "things.read")
+    .markPublic("GET /healthz")
+    .build();
+
+  it("counts every check, tagged by the declared key", () => {
+    const { provider, counts } = recordingMeter();
+    const enforcer = newEnforcer({ extract, requirements, deps: { metrics: provider } });
+
+    enforcer.decideDeclared(holding("things.read"), "GET /things");
+    enforcer.decideDeclared({}, "GET /healthz");
+
+    expect(counts["authorization.checks:GET /things"]).toBe(1);
+    expect(counts["authorization.checks:GET /healthz"]).toBe(1);
+    expect(counts["authorization.denials:GET /things"]).toBeUndefined();
+  });
+
+  it("separates the wiring bugs from an overreaching caller", () => {
+    // These three mean the service is enforcing something other than what its author intended, and
+    // they are the ones worth alerting on. An ordinary denial is just traffic.
+    const { provider, counts } = recordingMeter();
+    const enforcer = newEnforcer({ extract, requirements, deps: { metrics: provider } });
+
+    enforcer.decideDeclared({}, "GET /things"); // authentication did not run
+    enforcer.decideDeclared(holding("things.read"), "GET /admin"); // nobody declared it
+    enforcer.decide(holding("things.read"), []); // guarded with an empty list
+    enforcer.decideDeclared(holding("other.thing"), "GET /things"); // an actual overreach
+
+    expect(counts["authorization.missing_grants:GET /things"]).toBe(1);
+    expect(counts["authorization.undeclared:GET /admin"]).toBe(1);
+    expect(counts["authorization.empty_requirements:"]).toBe(1);
+    expect(counts["authorization.denials:GET /things"]).toBe(2);
+  });
+
+  it("logs the wiring bugs at error level and an overreach at debug", () => {
+    const { deps, errors } = recordingLogger();
+    const enforcer = newEnforcer({ extract, requirements, deps });
+
+    enforcer.decideDeclared({}, "GET /things");
+    enforcer.decideDeclared(holding("things.read"), "GET /admin");
+    enforcer.decide(holding("things.read"), []);
+    enforcer.decideDeclared(holding("other.thing"), "GET /things");
+
+    expect(errors).toHaveLength(3);
+    expect(errors.join("\n")).toContain("no grants available");
+  });
+});
+
+describe("Enforcer decisions", () => {
+  it("hands out a missing list that cannot be edited back into the decision", () => {
+    const enforcer = newEnforcer({ extract });
+    const decision: Decision = enforcer.decide(holding(), ["a", "b"]);
+
+    expect(decision.missing).toEqual(["a", "b"]);
+    (decision.missing as string[]).length = 0;
+
+    expect(enforcer.decide(holding(), ["a", "b"]).missing).toEqual(["a", "b"]);
+  });
+});

--- a/packages/authorization/src/enforcement.ts
+++ b/packages/authorization/src/enforcement.ts
@@ -1,0 +1,328 @@
+import {
+  ensureLogger,
+  type Logger,
+  type ObservabilityDeps,
+} from "@primandproper/observability";
+
+import { PermissionDeniedError } from "./errors.js";
+import type { GrantsExtractor } from "./grants.js";
+import { enforcementInstruments, type EnforcementInstruments } from "./instruments.js";
+import type { Permission } from "./permission.js";
+import type { Requirements } from "./requirements.js";
+
+/** Names the enforcer's logger and its instruments. */
+const o11yName = "authorization";
+
+/**
+ * Why a decision came out the way it did.
+ *
+ * The three wiring-bug reasons — `empty-requirement`, `no-grants`, `undeclared` — are worth
+ * separating from an ordinary `missing-permissions` denial, because they mean the service is
+ * enforcing something other than what its author intended rather than that a caller overreached.
+ */
+export type DecisionReason =
+  | "allowed"
+  | "public"
+  | "empty-requirement"
+  | "no-grants"
+  | "missing-permissions"
+  | "undeclared";
+
+/** The outcome of one authorization decision. */
+export interface Decision {
+  /**
+   * Whether the request may proceed.
+   *
+   * This is the honest verdict, always. Audit-only mode changes what an enforcer *does* with a
+   * `false` — it lets the request through — not what it reports here.
+   */
+  readonly allowed: boolean;
+  /** Why. */
+  readonly reason: DecisionReason;
+  /** The permissions the requester did not hold. Diagnostic only — never put this in a response body. */
+  readonly missing: readonly Permission[];
+  /** The requirements-table key this decision was made for, when it was table-driven. */
+  readonly key: string | undefined;
+}
+
+/**
+ * What a middleware calls to hand control to the next one.
+ *
+ * Typed loosely on purpose: hono returns a promise, koa returns a promise, and an express-style
+ * `next` returns nothing. `await`ing all three is correct.
+ */
+export type Next = () => unknown;
+
+/**
+ * Middleware in the `(ctx, next)` shape hono and koa use.
+ *
+ * A denial **throws** {@link PermissionDeniedError} rather than writing a response, because this
+ * package cannot know a consumer's error envelope and should not guess at one. The framework's
+ * own error hook — `app.onError` on hono, an error middleware on express — turns it into a 403,
+ * which also means a denial looks identical whether it came from here or from a handler that
+ * threw the same error itself.
+ *
+ * For an express-style `(req, res, next)` signature, adapt at the call site:
+ *
+ * ```ts
+ * const toExpress = (mw: Middleware<Request>) =>
+ *   (req: Request, _res: Response, next: NextFunction) => {
+ *     mw(req, async () => undefined).then(() => { next(); }, next);
+ *   };
+ * ```
+ */
+export type Middleware<Ctx> = (ctx: Ctx, next: Next) => Promise<void>;
+
+/** How to build an {@link Enforcer}. */
+export interface EnforcerOptions<Ctx> {
+  /** Bridges a consumer's request context to the authority it carries. Returning `undefined` denies. */
+  extract: GrantsExtractor<Ctx>;
+  /** The frozen table {@link Enforcer.enforce} looks routes up in. Required only for table-driven enforcement. */
+  requirements?: Requirements;
+  /**
+   * Evaluate and record every decision, but deny nothing.
+   *
+   * This is the rollout tool. Turning enforcement on across a service that never had it is
+   * otherwise a bet that every declaration is right on the first try. Deploy with it, watch
+   * `authorization.denials` and `authorization.undeclared` settle to zero, then remove it.
+   *
+   * It is the only mode in which an unauthorized request proceeds, which is why it is a code-level
+   * option rather than configuration, and why it announces itself in the log at construction.
+   */
+  auditOnly?: boolean;
+  /** Logger, tracer, and meter. Absent ones become noops. */
+  deps?: ObservabilityDeps;
+}
+
+/**
+ * Decides whether a request may proceed, and says so by throwing.
+ *
+ * The decision itself is `Grants.hasAll` — synchronous, infallible, a few map lookups. What this
+ * adds is the part that is easy to get wrong exactly once: the empty-list guard, the
+ * fail-closed behaviour for a route nobody declared, and instruments that distinguish "a caller
+ * overreached" from "this service is not enforcing what its author thought it was".
+ *
+ * Two ways to declare what a route needs, and they are the two platform-go ships:
+ *
+ * ```ts
+ * // At the registration site — the requirement sits next to the handler it guards.
+ * app.get("/recipes/:id", enforcer.require("recipes.read"), readRecipe);
+ *
+ * // Or from a frozen table, installed once — an undeclared route is denied.
+ * app.use(enforcer.enforce((c) => `${c.req.method} ${c.req.routePath}`));
+ * ```
+ *
+ * The table is the stronger of the two and the one to prefer where a framework exposes a matched
+ * route pattern, because only it can fail closed on a route nobody guarded — and only it supports
+ * {@link import("./requirements.js").assertRoutesDeclared}, which moves that failure to startup.
+ */
+export class Enforcer<Ctx> {
+  readonly #extract: GrantsExtractor<Ctx>;
+  readonly #requirements: Requirements | undefined;
+  readonly #auditOnly: boolean;
+  readonly #logger: Logger;
+  readonly #instruments: EnforcementInstruments;
+
+  /** @internal Use {@link newEnforcer}. */
+  constructor(options: EnforcerOptions<Ctx>) {
+    this.#extract = options.extract;
+    this.#requirements = options.requirements;
+    this.#auditOnly = options.auditOnly ?? false;
+    this.#logger = ensureLogger(options.deps?.logger).child(o11yName);
+    this.#instruments = enforcementInstruments(o11yName, options.deps);
+
+    if (this.#auditOnly) {
+      this.#logger.info(
+        "authorization enforcer running in audit-only mode; denials will be recorded but not enforced",
+      );
+    }
+  }
+
+  /**
+   * Decides `ctx` against an explicit list of required permissions, recording the decision.
+   *
+   * **An empty `required` denies.** Set algebra says a universal quantifier over nothing is
+   * vacuously true, and `Grants.hasAll([])` honestly returns `true` for that reason — but a
+   * *guard* installed with an empty list is far more likely to be a list that came back empty from
+   * configuration than an intent to admit everyone, and a route that needs no authorization simply
+   * carries no guard. This is the middleware row of the matrix in the package README.
+   */
+  decide(ctx: Ctx, required: readonly Permission[]): Decision {
+    return this.#decide(ctx, required, undefined);
+  }
+
+  /**
+   * Decides `ctx` against what the requirements table says `key` demands.
+   *
+   * A key the table does not declare is **denied**, which is what makes "public" a declaration
+   * rather than an omission. Throws if the enforcer was built without a table, since silently
+   * denying every route would look exactly like a policy that denies every route.
+   */
+  decideDeclared(ctx: Ctx, key: string): Decision {
+    const requirements = this.#requirements;
+    if (requirements === undefined) {
+      throw new TypeError(
+        "this enforcer was built without a requirements table; pass `requirements` to newEnforcer",
+      );
+    }
+
+    const requirement = requirements.lookup(key);
+
+    if (requirement === undefined) {
+      // A different bug from a denied request: the table is incomplete, not that a caller
+      // overreached. Counted separately and logged at a level that gets noticed.
+      this.#instruments.checks.add(1, { key });
+      this.#instruments.undeclared.add(1, { key });
+      this.#logger.error(
+        "denying request for a route with no declared authorization requirements",
+        new PermissionDeniedError(),
+        { key },
+      );
+      return this.#denied("undeclared", [], key);
+    }
+
+    if (requirement.kind === "public") {
+      this.#instruments.checks.add(1, { key });
+      return { allowed: true, reason: "public", missing: [], key };
+    }
+
+    return this.#decide(ctx, requirement.permissions, key);
+  }
+
+  /**
+   * Decides, and throws {@link PermissionDeniedError} on a denial.
+   *
+   * For a check inside a handler, where the requirement depends on the request body and cannot be
+   * declared at the route. Audit-only mode is honoured here too: it records the denial and returns
+   * normally.
+   */
+  authorize(ctx: Ctx, ...required: readonly Permission[]): void {
+    this.#raise(this.decide(ctx, required));
+  }
+
+  /**
+   * Middleware admitting only requests whose grants include every permission in `required`.
+   *
+   * Declaring at the registration site puts the requirement next to the handler it guards, which
+   * is where a reader is most likely to notice its absence. It cannot detect a route registered
+   * *without* a guard, though — for that, use {@link Enforcer.enforce} with a table.
+   *
+   * `required` is copied, so a caller mutating its own array afterwards cannot change what the
+   * route demands.
+   */
+  require(...required: readonly Permission[]): Middleware<Ctx> {
+    const frozen = [...required];
+    return async (ctx, next) => {
+      this.#raise(this.decide(ctx, frozen));
+      await next();
+    };
+  }
+
+  /**
+   * Middleware that looks each request's requirement up in the table, installed once for a whole
+   * server.
+   *
+   * `keyOf` derives the table key from the request context — typically the matched route pattern,
+   * `` `${method} ${pattern}` ``, or a gRPC full method name. It must return the pattern rather
+   * than the raw path: a raw path carries a resource identifier, so it would never match a
+   * declaration and every request would be denied as undeclared. Returning `undefined` — a router
+   * that has not matched yet, say — is treated as undeclared and denied.
+   */
+  enforce(keyOf: (ctx: Ctx) => string | undefined): Middleware<Ctx> {
+    return async (ctx, next) => {
+      const key = keyOf(ctx);
+      this.#raise(key === undefined ? this.#unmatched() : this.decideDeclared(ctx, key));
+      await next();
+    };
+  }
+
+  /** Reports whether this enforcer records decisions without acting on them. */
+  isAuditOnly(): boolean {
+    return this.#auditOnly;
+  }
+
+  #decide(ctx: Ctx, required: readonly Permission[], key: string | undefined): Decision {
+    const attrs = key === undefined ? undefined : { key };
+    this.#instruments.checks.add(1, attrs);
+
+    if (required.length === 0) {
+      this.#instruments.emptyRequirements.add(1, attrs);
+      this.#logger.error(
+        "denying request for a route guarded by an empty permission list",
+        new PermissionDeniedError(),
+        key === undefined ? {} : { key },
+      );
+      return this.#denied("empty-requirement", [], key);
+    }
+
+    const grants = this.#extract(ctx);
+    if (grants === undefined) {
+      // Usually means authentication did not run, or ran after this — a wiring bug rather than an
+      // overreaching caller, so it gets its own counter and a level that gets noticed.
+      this.#instruments.missingGrants.add(1, attrs);
+      this.#logger.error(
+        "no grants available for a request requiring authorization",
+        new PermissionDeniedError(required),
+        key === undefined ? {} : { key },
+      );
+      return this.#denied("no-grants", required, key);
+    }
+
+    const missing = grants.missing(required);
+    if (missing.length > 0) {
+      this.#logger.debug("denying request for missing permissions", {
+        ...(key === undefined ? {} : { key }),
+        missing,
+      });
+      return this.#denied("missing-permissions", missing, key);
+    }
+
+    return { allowed: true, reason: "allowed", missing: [], key };
+  }
+
+  /** A context whose key could not be derived: nothing was declared for it, so nothing admits it. */
+  #unmatched(): Decision {
+    this.#instruments.checks.add(1);
+    this.#instruments.undeclared.add(1);
+    this.#logger.error(
+      "denying request whose authorization key could not be determined",
+      new PermissionDeniedError(),
+    );
+    return this.#denied("undeclared", [], undefined);
+  }
+
+  #denied(
+    reason: DecisionReason,
+    missing: readonly Permission[],
+    key: string | undefined,
+  ): Decision {
+    this.#instruments.denials.add(1, key === undefined ? undefined : { key });
+    return { allowed: false, reason, missing: [...missing], key };
+  }
+
+  /** Turns a decision into the caller's outcome, honouring audit-only mode. */
+  #raise(decision: Decision): void {
+    if (decision.allowed || this.#auditOnly) {
+      return;
+    }
+    throw new PermissionDeniedError(decision.missing);
+  }
+}
+
+/**
+ * Builds an {@link Enforcer}.
+ *
+ * ```ts
+ * const enforcer = newEnforcer({
+ *   extract: (c) => c.get("grants"),
+ *   requirements: newRequirements()
+ *     .require("GET /recipes/:id", "recipes.read")
+ *     .markPublic("GET /healthz")
+ *     .build(),
+ *   deps: { logger, metrics },
+ * });
+ * ```
+ */
+export function newEnforcer<Ctx>(options: EnforcerOptions<Ctx>): Enforcer<Ctx> {
+  return new Enforcer(options);
+}

--- a/packages/authorization/src/errors.ts
+++ b/packages/authorization/src/errors.ts
@@ -64,3 +64,90 @@ export function isInvalidPolicy(err: unknown, problem?: PolicyProblem): boolean 
     ? err.code.startsWith(`${POLICY_INVALID_CODE}/`)
     : err.code === `${POLICY_INVALID_CODE}/${problem}`;
 }
+
+/** The `code` every {@link InvalidRequirementsError} carries. */
+export const REQUIREMENTS_INVALID_CODE = "authorization/requirements-invalid";
+
+/** Why a single declaration in a requirements table was rejected. */
+export interface RequirementProblem {
+  /** Which rule the declaration broke. */
+  kind: "empty-key" | "duplicate-key" | "no-permissions-required" | "empty-permission";
+  /** The route or method key the problem belongs to. Empty for an `empty-key` problem. */
+  key: string;
+  /** A sentence naming the problem, suitable for a startup log. */
+  message: string;
+}
+
+/**
+ * A requirements table was rejected rather than built.
+ *
+ * It carries **every** problem the builder found rather than the first. A table assembled from a
+ * dozen feature modules usually has more than one, and fixing them a restart at a time is
+ * miserable.
+ */
+export class InvalidRequirementsError extends PlatformError {
+  /** Every problem found, in the order the builder reports them (declaration order, then key order). */
+  readonly problems: readonly RequirementProblem[];
+
+  constructor(problems: readonly RequirementProblem[], options?: ErrorOptions) {
+    super(
+      REQUIREMENTS_INVALID_CODE,
+      `invalid authorization requirements: ${problems.map((p) => p.message).join("; ")}`,
+      options,
+    );
+    this.name = "InvalidRequirementsError";
+    this.problems = [...problems];
+  }
+}
+
+/** True when `err` is an {@link InvalidRequirementsError}. */
+export function isInvalidRequirements(err: unknown): boolean {
+  return isPlatformError(err, REQUIREMENTS_INVALID_CODE);
+}
+
+/** The `code` every {@link RouteCoverageError} carries. */
+export const ROUTE_COVERAGE_CODE = "authorization/route-coverage";
+
+/**
+ * A server registered routes its requirements table does not account for.
+ *
+ * This is the failure the boot-time check exists to produce, and it is deliberately a startup
+ * crash rather than a runtime denial: a route nobody declared is a route nobody decided about,
+ * and finding that out on deploy is far cheaper than finding it out from a caller.
+ */
+export class RouteCoverageError extends PlatformError {
+  /** Routes the server registered that the table neither requires permissions for nor marks public. */
+  readonly undeclared: readonly string[];
+  /** Keys the table declares that the server never registered — usually a rename that lost its declaration. */
+  readonly stale: readonly string[];
+
+  constructor(
+    undeclared: readonly string[],
+    stale: readonly string[],
+    options?: ErrorOptions,
+  ) {
+    super(ROUTE_COVERAGE_CODE, coverageMessage(undeclared, stale), options);
+    this.name = "RouteCoverageError";
+    this.undeclared = [...undeclared];
+    this.stale = [...stale];
+  }
+}
+
+/** True when `err` is a {@link RouteCoverageError}. */
+export function isRouteCoverage(err: unknown): boolean {
+  return isPlatformError(err, ROUTE_COVERAGE_CODE);
+}
+
+function coverageMessage(
+  undeclared: readonly string[],
+  stale: readonly string[],
+): string {
+  const parts: string[] = [];
+  if (undeclared.length > 0) {
+    parts.push(`undeclared routes: ${undeclared.join(", ")}`);
+  }
+  if (stale.length > 0) {
+    parts.push(`declared but never registered: ${stale.join(", ")}`);
+  }
+  return `authorization route coverage: ${parts.join("; ")}`;
+}

--- a/packages/authorization/src/grants.ts
+++ b/packages/authorization/src/grants.ts
@@ -46,9 +46,8 @@ export class Grants {
    * Calling it with no permissions is vacuously `true`, so a list that reached zero length by
    * accident authorizes everyone. {@link PermissionSet.hasAll} carries the full matrix of which
    * declaration sites guard the empty case and how — read it before calling this from anything
-   * that decides access. Code deciding access from a *derived* list must reject the empty case
-   * itself before calling this, since the enforcement layer that would otherwise do it is not
-   * ported yet.
+   * that decides access. Code deciding access from a *derived* list should route it through an
+   * `Enforcer` instead, which denies the empty case rather than vacuously allowing it.
    */
   hasAll(perms: Iterable<Permission>): boolean {
     for (const p of perms) {

--- a/packages/authorization/src/index.node.ts
+++ b/packages/authorization/src/index.node.ts
@@ -1,13 +1,17 @@
 /**
- * Node entry: the checking half the browser also gets, plus policy resolution.
+ * Node entry: the checking half the browser also gets, plus policy resolution and server
+ * enforcement.
  *
  * The asymmetry is the design. Checking is synchronous, infallible, and identical on both sides;
- * resolving role names to permissions may touch a database and stays on the server. A caller
- * resolves once when it builds a session and checks many times per request against the resulting
- * {@link Grants}.
+ * resolving role names to permissions may touch a database and stays on the server, and so does
+ * deciding whether to admit a request at all. A caller resolves once when it builds a session and
+ * checks many times per request against the resulting {@link Grants}.
  */
+export * from "./enforcement.js";
 export * from "./errors.js";
 export * from "./grants.js";
+export * from "./instruments.js";
 export * from "./permission.js";
 export * from "./policy.js";
+export * from "./requirements.js";
 export { StaticPolicyResolver } from "./providers/static.js";

--- a/packages/authorization/src/instruments.ts
+++ b/packages/authorization/src/instruments.ts
@@ -1,0 +1,62 @@
+import {
+  makeMetrics,
+  type Metrics,
+  type ObservabilityDeps,
+} from "@primandproper/observability";
+
+type Counter = ReturnType<Metrics["counter"]>;
+
+/**
+ * What an {@link import("./enforcement.js").Enforcer} reports.
+ *
+ * Three of the four count wiring bugs rather than misbehaving callers, and those are the ones to
+ * alert on: `undeclared`, `emptyRequirements`, and `missingGrants` all mean the service is
+ * enforcing something other than what its author intended. `denials` alone is ordinary traffic —
+ * a caller reaching for something it may not have.
+ *
+ * Every instrument carries a `key` attribute when enforcement was table-driven, because one
+ * enforcer serves every route and a single mis-declared one is invisible in the total. The key is
+ * a declared route pattern, so its cardinality is bounded by the table; a raw URL path is not, and
+ * is never used as a label here.
+ */
+export interface EnforcementInstruments {
+  /** Every decision the enforcer made, allowed or not. The denominator. */
+  checks: Counter;
+  /** Decisions that came out `false`, whether or not audit-only let the request through. */
+  denials: Counter;
+  /** Requests reaching a guarded route with no determinable authority — usually authentication did not run, or ran after this. */
+  missingGrants: Counter;
+  /** Requests for a key the requirements table does not declare. The table is incomplete. */
+  undeclared: Counter;
+  /** Guarded routes whose requirement list was empty — the vacuous-allow hazard, denied and counted. */
+  emptyRequirements: Counter;
+}
+
+/** Builds the enforcer's instruments, defaulting to the noop meter. */
+export function enforcementInstruments(
+  o11yName: string,
+  deps: ObservabilityDeps | undefined,
+): EnforcementInstruments {
+  const metrics = makeMetrics(o11yName, deps?.metrics);
+  return {
+    checks: metrics.counter("authorization.checks", {
+      description: "Count of authorization decisions made, allowed or denied.",
+    }),
+    denials: metrics.counter("authorization.denials", {
+      description:
+        "Count of authorization decisions that came out denied, including ones audit-only mode let through.",
+    }),
+    missingGrants: metrics.counter("authorization.missing_grants", {
+      description:
+        "Count of requests reaching a guarded route with no determinable authority.",
+    }),
+    undeclared: metrics.counter("authorization.undeclared", {
+      description:
+        "Count of requests for a key absent from the requirements table, which are denied.",
+    }),
+    emptyRequirements: metrics.counter("authorization.empty_requirements", {
+      description:
+        "Count of guarded routes whose required-permission list was empty, which are denied.",
+    }),
+  };
+}

--- a/packages/authorization/src/permission.ts
+++ b/packages/authorization/src/permission.ts
@@ -56,16 +56,12 @@ export class PermissionSet {
    * | site | empty list |
    * | --- | --- |
    * | `PermissionSet.hasAll()` / `Grants.hasAll()` | `true` — set algebra |
-   * | server enforcement middleware | denies — an empty list is far more likely a bug |
-   * | a frozen requirements table | refuses to build at all |
+   * | `Enforcer.decide()` / `require()` / `enforce()` | denies — an empty list is far more likely a bug |
+   * | `RequirementsBuilder.build()` | refuses to build at all |
    *
    * "Empty means allow" is therefore only ever safe with a list you wrote literally. Anything
-   * derived from configuration, a database, or a lookup must be checked for emptiness before it
-   * reaches here.
-   *
-   * **The last two rows describe an enforcement layer this package does not ship yet** — see
-   * "Not ported" in the README. Until it lands, guarding a derived list is the caller's job, and
-   * this is the hazard to guard against.
+   * derived from configuration, a database, or a lookup should reach an `Enforcer` rather than
+   * this method, because the enforcement layer is where that check already lives.
    */
   hasAll(perms: Iterable<Permission>): boolean {
     for (const p of perms) {

--- a/packages/authorization/src/requirements.test.ts
+++ b/packages/authorization/src/requirements.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  InvalidRequirementsError,
+  isInvalidRequirements,
+  isRouteCoverage,
+  RouteCoverageError,
+} from "./errors.js";
+import { assertRoutesDeclared, newRequirements } from "./requirements.js";
+
+/** Builds and returns the error a builder threw, failing the test if it built cleanly. */
+function buildError(build: () => unknown): InvalidRequirementsError {
+  try {
+    build();
+  } catch (err) {
+    expect(isInvalidRequirements(err)).toBe(true);
+    return err as InvalidRequirementsError;
+  }
+  return expect.unreachable("expected build to throw");
+}
+
+describe("RequirementsBuilder", () => {
+  it("freezes what each key demands", () => {
+    const reqs = newRequirements()
+      .require("GET /recipes/:id", "recipes.read")
+      .require("POST /recipes", "recipes.create", "recipes.read")
+      .markPublic("GET /healthz")
+      .build();
+
+    expect(reqs.lookup("GET /recipes/:id")).toEqual({
+      kind: "permissions",
+      permissions: ["recipes.read"],
+    });
+    expect(reqs.lookup("POST /recipes")).toEqual({
+      kind: "permissions",
+      permissions: ["recipes.create", "recipes.read"],
+    });
+    expect(reqs.lookup("GET /healthz")).toEqual({ kind: "public" });
+    expect(reqs.size).toBe(3);
+  });
+
+  it("reports an undeclared key as undeclared rather than as requiring nothing", () => {
+    // The fail-closed path: enforcement must be able to tell "nothing required" from "never
+    // decided about", and only the second one is a denial.
+    const reqs = newRequirements().markPublic("GET /healthz").build();
+    expect(reqs.lookup("GET /admin")).toBeUndefined();
+  });
+
+  it("refuses to build a key required with no permissions", () => {
+    // Vacuous truth would make this authorize everyone while reading like a restriction. Saying
+    // "needs nothing" is markPublic's job, and it looks like what it does.
+    const err = buildError(() => newRequirements().require("GET /things").build());
+
+    expect(err.problems).toHaveLength(1);
+    expect(err.problems[0]?.kind).toBe("no-permissions-required");
+    expect(err.problems[0]?.key).toBe("GET /things");
+  });
+
+  it("reports every problem rather than the first", () => {
+    // A table assembled from a dozen feature modules usually has more than one, and fixing them a
+    // restart at a time is miserable.
+    const err = buildError(() =>
+      newRequirements()
+        .require("GET /a")
+        .require("GET /b", "")
+        .require("", "things.read")
+        .markPublic("GET /c")
+        .require("GET /c", "things.read")
+        .build(),
+    );
+
+    expect(err.problems.map((p) => p.kind).sort()).toEqual([
+      "duplicate-key",
+      "empty-key",
+      "empty-permission",
+      "no-permissions-required",
+    ]);
+    expect(err.message).toContain("GET /a");
+  });
+
+  it("reports a key declared twice rather than letting one silently win", () => {
+    const err = buildError(() =>
+      newRequirements()
+        .require("GET /things", "things.read")
+        .require("GET /things", "things.admin")
+        .build(),
+    );
+
+    expect(err.problems.map((p) => p.kind)).toEqual(["duplicate-key"]);
+  });
+
+  it("counts a key declared public twice as a duplicate too", () => {
+    const err = buildError(() =>
+      newRequirements().markPublic("GET /healthz").markPublic("GET /healthz").build(),
+    );
+
+    expect(err.problems.map((p) => p.kind)).toEqual(["duplicate-key"]);
+  });
+
+  it("rejects an empty permission in a declaration", () => {
+    const err = buildError(() => newRequirements().require("GET /things", "").build());
+    expect(err.problems.map((p) => p.kind)).toContain("empty-permission");
+  });
+
+  it("merges records, which is the shape a feature module exports", () => {
+    const recipes = { "GET /recipes/:id": ["recipes.read"] };
+    const billing = { "POST /refunds": ["billing.refund"] };
+
+    const reqs = newRequirements().requireEach(recipes).requireEach(billing).build();
+
+    expect(reqs.keys()).toEqual(["GET /recipes/:id", "POST /refunds"]);
+  });
+
+  it("reports a key two records both declare", () => {
+    const err = buildError(() =>
+      newRequirements()
+        .requireEach({ "GET /things": ["things.read"] })
+        .requireEach({ "GET /things": ["things.admin"] })
+        .build(),
+    );
+
+    expect(err.problems.map((p) => p.kind)).toEqual(["duplicate-key"]);
+  });
+
+  it("copies a permission list in, so a later mutation cannot edit the requirement", () => {
+    const permissions = ["things.read"];
+    const reqs = newRequirements()
+      .require("GET /things", ...permissions)
+      .build();
+
+    permissions.push("things.admin");
+
+    expect(reqs.lookup("GET /things")).toEqual({
+      kind: "permissions",
+      permissions: ["things.read"],
+    });
+  });
+
+  it("lists its keys sorted, for coverage assertions", () => {
+    const reqs = newRequirements()
+      .require("GET /z", "z.read")
+      .markPublic("GET /a")
+      .build();
+
+    expect(reqs.keys()).toEqual(["GET /a", "GET /z"]);
+  });
+});
+
+describe("assertRoutesDeclared", () => {
+  const reqs = newRequirements()
+    .require("GET /recipes/:id", "recipes.read")
+    .markPublic("GET /healthz")
+    .build();
+
+  it("passes when every registered route is accounted for", () => {
+    expect(() => {
+      assertRoutesDeclared(["GET /recipes/:id", "GET /healthz"], reqs);
+    }).not.toThrow();
+  });
+
+  it("names every route the table does not cover", () => {
+    // This is the check platform-go could not have: a route nobody declared is caught before the
+    // first request rather than by a caller.
+    try {
+      assertRoutesDeclared(
+        ["GET /recipes/:id", "GET /healthz", "DELETE /recipes/:id"],
+        reqs,
+      );
+    } catch (err) {
+      expect(isRouteCoverage(err)).toBe(true);
+      expect((err as RouteCoverageError).undeclared).toEqual(["DELETE /recipes/:id"]);
+      expect((err as RouteCoverageError).message).toContain("DELETE /recipes/:id");
+      return;
+    }
+    expect.unreachable("expected the coverage assertion to throw");
+  });
+
+  it("reports a rename from both sides", () => {
+    // The new name is undeclared and the old one is stale; together they name the mistake far
+    // more precisely than either alone.
+    try {
+      assertRoutesDeclared(["GET /recipes/:recipeID", "GET /healthz"], reqs);
+    } catch (err) {
+      expect((err as RouteCoverageError).undeclared).toEqual(["GET /recipes/:recipeID"]);
+      expect((err as RouteCoverageError).stale).toEqual(["GET /recipes/:id"]);
+      return;
+    }
+    expect.unreachable("expected the coverage assertion to throw");
+  });
+
+  it("tolerates a stale declaration when told to", () => {
+    // One shared table can intentionally cover more than a given server registers.
+    expect(() => {
+      assertRoutesDeclared(["GET /healthz"], reqs, { allowStaleDeclarations: true });
+    }).not.toThrow();
+  });
+
+  it("ignores duplicate entries in the router's route list", () => {
+    expect(() => {
+      assertRoutesDeclared(["GET /healthz", "GET /healthz", "GET /recipes/:id"], reqs);
+    }).not.toThrow();
+  });
+});

--- a/packages/authorization/src/requirements.ts
+++ b/packages/authorization/src/requirements.ts
@@ -1,0 +1,248 @@
+import {
+  InvalidRequirementsError,
+  RouteCoverageError,
+  type RequirementProblem,
+} from "./errors.js";
+import type { Permission } from "./permission.js";
+
+/** What a declared key demands, as the table stores it. */
+export type Requirement =
+  | { readonly kind: "permissions"; readonly permissions: readonly Permission[] }
+  | { readonly kind: "public" };
+
+/**
+ * The frozen table of what each route or method demands.
+ *
+ * It is immutable once built, which is why enforcement needs no lock and no defensive copy on the
+ * hot path: a map that is never written after startup does not need protecting on every request.
+ *
+ * **A key absent from the table is denied.** Being public is a declaration, never an omission —
+ * forgetting to declare a route fails closed, and {@link assertRoutesDeclared} turns that failure
+ * into a startup crash rather than a 403 someone reports later.
+ */
+export class Requirements {
+  readonly #byKey: ReadonlyMap<string, Requirement>;
+
+  /** @internal Use {@link newRequirements}. */
+  private constructor(byKey: ReadonlyMap<string, Requirement>) {
+    this.#byKey = byKey;
+  }
+
+  /** @internal */
+  static build(byKey: ReadonlyMap<string, Requirement>): Requirements {
+    return new Requirements(byKey);
+  }
+
+  /**
+   * What `key` demands, or `undefined` when it was never declared.
+   *
+   * The `undefined` is the fail-closed path and callers must treat it as a denial rather than as
+   * "nothing required".
+   */
+  lookup(key: string): Requirement | undefined {
+    return this.#byKey.get(key);
+  }
+
+  /**
+   * Every declared key, sorted.
+   *
+   * It exists so a consumer can assert its table covers everything its server registers — the
+   * check that turns "we remembered to declare everything" from a convention into a test. See
+   * {@link assertRoutesDeclared}.
+   */
+  keys(): string[] {
+    return [...this.#byKey.keys()].sort();
+  }
+
+  /** The number of declared keys. */
+  get size(): number {
+    return this.#byKey.size;
+  }
+}
+
+/**
+ * Accumulates declarations and validates them as a whole.
+ *
+ * Every method returns the builder, so declarations chain. Nothing is validated until
+ * {@link RequirementsBuilder.build}, which is what lets it report every problem at once.
+ */
+export class RequirementsBuilder {
+  readonly #byKey = new Map<string, Requirement>();
+  readonly #declaredCount = new Map<string, number>();
+  readonly #problems: RequirementProblem[] = [];
+
+  /**
+   * Declares that `key` demands every permission in `permissions`.
+   *
+   * Declaring zero permissions is a **build error** rather than a way to say "any authenticated
+   * caller": it reads as a requirement while behaving as an allow, and that gap is exactly where
+   * an authorization hole hides. Say {@link RequirementsBuilder.markPublic} instead, which means
+   * the same thing and looks like it.
+   */
+  require(key: string, ...permissions: readonly Permission[]): this {
+    this.#count(key);
+
+    if (key === "") {
+      this.#problems.push({
+        kind: "empty-key",
+        key: "",
+        message: "a requirement was declared for an empty key",
+      });
+    } else if (permissions.length === 0) {
+      this.#problems.push({
+        kind: "no-permissions-required",
+        key,
+        message: `${key} was required with no permissions; use markPublic to declare it needs none`,
+      });
+    }
+
+    for (const permission of permissions) {
+      if (permission === "") {
+        this.#problems.push({
+          kind: "empty-permission",
+          key,
+          message: `${key} requires an empty permission`,
+        });
+      }
+    }
+
+    if (key !== "" && permissions.length > 0) {
+      // Cloned, so a caller mutating its own array afterwards cannot edit the requirement.
+      this.#byKey.set(key, { kind: "permissions", permissions: [...permissions] });
+    }
+
+    return this;
+  }
+
+  /**
+   * Declares requirements from a record, which is the shape a feature module naturally exports for
+   * its own routes.
+   *
+   * Several such records merge into one table, and a key declared by two of them is reported as a
+   * duplicate rather than silently taking whichever was applied last.
+   */
+  requireEach(declarations: Readonly<Record<string, readonly Permission[]>>): this {
+    for (const key of Object.keys(declarations).sort()) {
+      this.require(key, ...(declarations[key] ?? []));
+    }
+    return this;
+  }
+
+  /**
+   * Declares that `key` requires no authorization.
+   *
+   * Named `markPublic` rather than `public` because the latter reads as a visibility modifier at
+   * every call site in TypeScript. It is the only way to say "this needs nothing", and saying it
+   * is mandatory: an undeclared key is denied, so forgetting to declare a route fails closed and
+   * loudly, while forgetting to mark one public fails closed and obviously.
+   */
+  markPublic(key: string): this {
+    this.#count(key);
+
+    if (key === "") {
+      this.#problems.push({
+        kind: "empty-key",
+        key: "",
+        message: "a public declaration was made for an empty key",
+      });
+      return this;
+    }
+
+    this.#byKey.set(key, { kind: "public" });
+
+    return this;
+  }
+
+  /**
+   * Validates every accumulated declaration and freezes them.
+   *
+   * Throws {@link InvalidRequirementsError} carrying **all** the problems, not the first — a table
+   * assembled from a dozen feature modules usually has more than one, and fixing them a restart at
+   * a time is miserable.
+   */
+  build(): Requirements {
+    const problems: RequirementProblem[] = [...this.#problems];
+
+    for (const key of [...this.#declaredCount.keys()].sort()) {
+      if ((this.#declaredCount.get(key) ?? 0) > 1) {
+        problems.push({
+          kind: "duplicate-key",
+          key,
+          message: `${key} was declared more than once`,
+        });
+      }
+    }
+
+    if (problems.length > 0) {
+      throw new InvalidRequirementsError(problems);
+    }
+
+    return Requirements.build(new Map(this.#byKey));
+  }
+
+  #count(key: string): void {
+    this.#declaredCount.set(key, (this.#declaredCount.get(key) ?? 0) + 1);
+  }
+}
+
+/** Starts a {@link RequirementsBuilder}. */
+export function newRequirements(): RequirementsBuilder {
+  return new RequirementsBuilder();
+}
+
+/** Options for {@link assertRoutesDeclared}. */
+export interface RouteCoverageOptions {
+  /**
+   * Tolerate keys the table declares that `routes` does not contain.
+   *
+   * Default `false`. A stale declaration is not a security hole, but it is usually a rename whose
+   * new name landed in the router and not in the table — in which case the new name shows up as
+   * undeclared too, and the pair together names the mistake precisely. Set this when one shared
+   * table intentionally covers more than a given server registers.
+   */
+  allowStaleDeclarations?: boolean;
+}
+
+/**
+ * Asserts that every route the server registered is accounted for by `requirements`.
+ *
+ * This is the check platform-go could not have. Its HTTP middleware runs before the mux has
+ * matched, so a route pattern is not knowable there and an unguarded route cannot be detected at
+ * all. In TypeScript the route table is enumerable at startup — `app.routes` on hono, the router
+ * stack on express, `printRoutes` on fastify — so "every registered route either requires
+ * permissions or is explicitly marked public" becomes a fact checked before the first request
+ * instead of a convention:
+ *
+ * ```ts
+ * assertRoutesDeclared(
+ *   app.routes.map((r) => `${r.method} ${r.path}`),
+ *   requirements,
+ * );
+ * ```
+ *
+ * Run it at boot, and in a test — the test tells whoever added the route what they forgot, which
+ * is cheaper than a crash loop telling an on-call engineer.
+ *
+ * Throws {@link RouteCoverageError} naming every uncovered route at once. Duplicate entries in
+ * `routes` are ignored; the router's own route list often contains them.
+ */
+export function assertRoutesDeclared(
+  routes: Iterable<string>,
+  requirements: Requirements,
+  options?: RouteCoverageOptions,
+): void {
+  const registered = new Set(routes);
+
+  const undeclared = [...registered]
+    .filter((route) => requirements.lookup(route) === undefined)
+    .sort();
+
+  const stale =
+    options?.allowStaleDeclarations === true
+      ? []
+      : requirements.keys().filter((key) => !registered.has(key));
+
+  if (undeclared.length > 0 || stale.length > 0) {
+    throw new RouteCoverageError(undeclared, stale);
+  }
+}


### PR DESCRIPTION
Toward #9. Lands the enforcement half of `authorization` — the piece the issue's follow-up comment called "the most valuable remaining piece" — plus the boot-time route check flagged as the opportunity Go did not have.

## Why

The empty-list matrix in the README has three rows. Two of them described code that did not exist:

| site | empty list |
| --- | --- |
| `PermissionSet.hasAll()` / `Grants.hasAll()` | `true` — set algebra |
| **`Enforcer.decide()` / `require()` / `enforce()`** | **denies** |
| **`RequirementsBuilder.build()`** | **refuses to build at all** |

Until now a caller building a requirement list from anything other than a literal had to check it for emptiness itself, which is exactly the burden the enforcement layer exists to remove.

## What landed

**`Enforcer`** decides whether a request may proceed and says so by throwing. The decision is still `Grants.hasAll` — synchronous, infallible, a few map lookups. What the enforcer adds is the part that is easy to get wrong exactly once: the empty-list guard, fail-closed behaviour for a route nobody declared, and instruments that tell "a caller overreached" apart from "this service is not enforcing what its author thought it was".

Two ways to declare what a route needs, and they are the two platform-go ships:

```ts
// At the registration site — the requirement sits next to the handler it guards.
app.get("/recipes/:id", enforcer.require("recipes.read"), readRecipe);

// Or from a frozen table, installed once. An undeclared route is denied.
app.use(enforcer.enforce((c) => `${c.req.method} ${c.req.routePath}`));
```

**`Requirements`** is frozen once built, so enforcement needs no lock. `build()` refuses a key required with zero permissions — it reads as a restriction while behaving as an allow — and reports *every* problem it found rather than the first, because a table assembled from a dozen feature modules usually has more than one. An undeclared key is denied, so `markPublic` is how a route opts out and being public is a declaration rather than an omission.

**`assertRoutesDeclared`** is the check platform-go lists as its known gap. Its HTTP middleware runs before the mux has matched, so a route pattern is not knowable there and an unguarded route is undetectable. In TypeScript the route table is enumerable at startup:

```ts
assertRoutesDeclared(app.routes.map((r) => `${r.method} ${r.path}`), requirements);
```

It reports a rename from both sides — the new name as undeclared, the old one as stale — which names the mistake more precisely than either half alone.

**`auditOnly`** records every decision without acting on it, for turning enforcement on across a service that never had it. It announces itself in the log at construction, since it is the only mode in which an unauthorized request proceeds.

**Five instruments**, each carrying the declared route key when enforcement was table-driven (bounded cardinality — a raw path is never used as a label). Three of them — `missing_grants`, `undeclared`, `empty_requirements` — count wiring bugs rather than misbehaving callers, and are the ones to alert on.

## Two design calls worth flagging

- **Middleware is `(ctx, next)`, generic over the context type**, rather than framework-specific. hono and koa use it directly; an express adapter is three lines and shown in the `Middleware` doc comment. The repo has no HTTP framework dependency and this does not add one.
- **A denial throws `PermissionDeniedError` rather than writing a response.** platform-go has `WithDenyHandler` because Go's middleware holds a `ResponseWriter`; here the framework's own error hook is the better seam, and routing the denial through it makes a middleware denial look identical to a handler that threw the same error itself. The message stays the constant `"permission denied"` — which permission was missing goes to the log and stops there.

## Still open on #9

- A database-backed resolver, plus the cached-resolver wrapper `PolicyInvalidator` was declared for.
- A `config.ts` provider factory.

## Verification

`pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm format:check`, `pnpm build` — all clean; 47/47 turbo tasks pass. 42 new tests across `requirements.test.ts` and `enforcement.test.ts`, including the security assertion that a denial does not disclose the permission taxonomy, and coverage of every wiring-bug path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uhrZu2juqReVTho9PWQ5e